### PR TITLE
[이도요] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,7 @@
     <header>
       <a href="/"
         ><img
-          src="images/logo/panda-market-logo.png"
-          alt="판다마켓 홈"
-          width="153"
+          src="images/logo/panda-market-logo.png" alt="판다마켓 홈" width="153"
       /></a>
       <a href="login.html" id="loginLinkButton" class="button">로그인</a>
     </header>
@@ -38,43 +36,33 @@
 
       <section id="features" class="wrapper">
         <div class="feature">
-          <img
-            src="images/home/feature1-image.png"
-            alt="인기 상품"
-            width="50%"
-          />
+          <img src="images/home/feature1-image.png" alt="인기 상품"/>
           <div class="feature-content">
-            <h2 class="feature-tag">Hot item</h2>
+            <h2>Hot item</h2>
             <h1>인기 상품을<span class="feature-line-break"<br /></span>확인해 보세요</h1>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
           </div>
         </div>
+
         <div class="feature">
+          <img src="images/home/feature2-image.png" alt="검색 기능"/>
           <div class="feature-content">
-            <h2 class="feature-tag">Search</h2>
+            <h2>Search</h2>
             <h1>구매를 원하는<span class="feature-line-break"<br /></span>상품을 검색하세요</h1>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
             </p>
           </div>
-          <img
-            src="images/home/feature2-image.png"
-            alt="검색 기능"
-            width="50%"
-          />
         </div>
+
         <div class="feature">
-          <img
-            src="images/home/feature3-image.png"
-            alt="판매 상품 등록"
-            width="50%"
-          />
+          <img src="images/home/feature3-image.png" alt="판매 상품 등록"/>
           <div class="feature-content">
-            <h2 class="feature-tag">Register</h2>
-            <h1>판매를 원하는<br />상품을 등록하세요</h1>
+            <h2>Register</h2>
+            <h1>판매를 원하는<span class="feature-line-break"<br /></span>상품을 등록하세요</h1>
             <p class="feature-description">
               어떤 물건이든 판매하고 싶은 상품을
               <br />쉽게 등록하세요

--- a/index.html
+++ b/index.html
@@ -3,71 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- 브라우저 탭에 표시하고 싶은 제목을 적어주세요. -->
     <title>판다마켓</title>
-    <!-- 
-      웹사이트를 식별하기 위해 브라우저에 표시하는 작은 아이콘을 '파비콘(Favicon)'이라고 합니다. 
-      일반적으로 16x16px의 .ico 확장자로 되어 있고, 온라인에서 favicon generator를 찾아 사용하면 편리하게 이미지를 파비콘으로 전환할 수 있습니다. 
-    -->
     <link rel="icon" href="images/logo/favicon.ico" />
-    <!-- 외부 폰트 Pretendard의 스타일시트를 링크해 주세요. -->
     <link
       rel="stylesheet"
       as="style"
       crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    />
-    <!-- 스타일시트를 링크해 주세요. styles라는 폴더를 만들어 웹사이트 전역에서 공통으로 사용되는 global 스타일링과 각 페이지 별로 특정적인 스타일링을 위한 파일을 나눠 작성하면 가독성을 개선할 수 있어요. -->
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
   </head>
 
   <body>
-    <!-- 
-      <header>는 일반적으로 로고, 내비게이션 메뉴, 검색창 등의 요소로 구성됩니다. 
-      내비게이션 메뉴 버튼이 여러 개라면 <nav> 시맨틱 태그로 감싸주어 레이아웃을 명확하게 해주면 좋습니다. 
-    -->
     <header>
-      <!-- 
-        - 로고 클릭 시 홈페이지로 이동. index.html로 이동할 때는 href='/'를 사용하면 됩니다. 
-        - <button>과 <a> 태그 두 가지 모두 사용 가능하지만, 단순한 페이지 간 또는 페이지 내에서의 이동에는 <a> 태그를 사용하고, 클릭 시 특정 이벤트가 발생하는 경우에는 <button> 태그를 사용하는 것이 권장됩니다.
-        (<button>을 사용했다면 커서 유형을 pointer로 바꿔주는 것을 잊지 마세요!)
-      -->
-      <!-- 
-        - 이미지 또한 images 폴더를 만들어 카테고리별로 정리해 주면 좋습니다.
-        - 이미지 최적화: 각 이미지의 특징에 따라 알맞은 형식으로 저장하는 것도 웹사이트의 효율에 영향을 미칩니다. 
-          (1) 벡터 기반의 SVG 파일로 저장하면 확대해도 이미지가 깨지지 않는다는 장점이 있습니다. 로고, 아이콘 등 단순한 그래픽의 경우에는 용량이 매우 작지만, 복잡한 그래픽의 경우 용량이 PNG보다 훨씬 커지는 경우가 있으니 주의하세요.
-          (2) JPG/JPEG는 PNG보다 압축률이 높지만 품질 저하가 발생할 수 있습니다. 복잡한 이미지에 적합하며, 배경 이미지 등에 많이 사용됩니다.
-          (3) 투명한 배경이 필요할 때는 PNG를 많이 사용합니다. 품질 저하 없이 저장이 가능하지만, 용량이 큰 경우가 많아 https://tinypng.com/ 같은 사이트를 이용해 이미지 압축을 한 번 하고 프로젝트에 추가하는 것이 권장됩니다.
-        - 사용자가 화면을 확대하거나 고해상도 화면을 사용할 가능성을 대비해 이미지를 실제 필요한 크기보다 2배수 또는 3배수로 저장하는 경우가 많습니다.
-        - 이미지 삽입할 때 잊지 말고 alt 속성에 이미지를 묘사하는 대체 텍스트를 넣어주세요!
-      -->
       <a href="/"
         ><img
           src="images/logo/panda-market-logo.png"
           alt="판다마켓 홈"
           width="153"
       /></a>
-      <!-- 
-        id 이름은 camelCase(단어 연결 시 맨 처음 단어를 제외한 단어들의 첫 글자를 대문자로 표기)로, 
-        class 이름은 kebab-case(단어를 하이픈(-)으로 구분)를 사용하는 것을 권장합니다.
-        하지만 팀마다 선호하는 스타일이 다르기 때문에 naming convention 등 정해진 규칙에 따라 통일성 있게 사용하는 것이 더 중요합니다.
-      -->
-      <!-- 클릭 시 로그인 페이지로 이동. login.html 파일을 생성해 임시 페이지를 만들어 주세요. -->
       <a href="login.html" id="loginLinkButton" class="button">로그인</a>
     </header>
 
-    <!-- 
-      웹페이지의 주요 콘텐츠는 <main> 시맨틱 태그에 넣어주세요. 
-      페이지 내용을 기능 및 특징에 따라 <section>으로 나누어 직관적으로 레이아웃을 살펴볼 수 있도록 구성해 보세요.
-    -->
     <main>
-      <!-- 홈페이지 랜딩 시 가장 상단에 위치해 눈을 사로잡는 역할을 하는 요소를 '히어로 섹션' 또는 '히어로 이미지' 라고 불러요. -->
-      <!-- 
-        전체적인 레이아웃, 디자인, 및 동작성을 먼저 살펴본 후에 비슷한 요소들을 묶어서 개발하면 코드의 재사용성을 높일 수 있어요. 
-        판다마켓 홈페이지에서는 최상단의 히어로 섹션(hero)과 하단 배너 섹션(bottomBanner)의 디자인이 비슷해서 "banner" 클래스로 묶어주었어요. 
-      -->
-      <!-- 각 섹션 내에 컨테이너의 최대 너비를 1200px로 제한하고 화면 중앙에 정렬해 주는 inner wrapper div를 씌워줬어요. -->
       <section id="hero" class="banner">
         <div class="wrapper">
           <h1>
@@ -79,12 +37,7 @@
       </section>
 
       <section id="features" class="wrapper">
-        <!-- features 섹션 내에 비슷한 레이아웃의 요소가 3개 있기 때문에 각 요소에게 feature 라는 클래스명을 부여했어요. -->
         <div class="feature">
-          <!-- 
-            화면 크기에 따라 이미지 사이즈가 자동으로 조정되도록 이미지의 width를 고정된 px값이 아닌 부모 컨테이너의 너비의 50%로 설정해 주었어요. 
-            각 요소의 크기를 설정하는 방식은 반응형 웹 디자인(responsive web design)을 개발할 때 중요한 고려사항이에요.
-          -->
           <img
             src="images/home/feature1-image.png"
             alt="인기 상품"
@@ -92,7 +45,7 @@
           />
           <div class="feature-content">
             <h2 class="feature-tag">Hot item</h2>
-            <h1>인기 상품을<br />확인해 보세요</h1>
+            <h1>인기 상품을<span class="feature-line-break"<br /></span>확인해 보세요</h1>
             <p class="feature-description">
               가장 HOT한 중고거래 물품을<br />판다마켓에서 확인해 보세요
             </p>
@@ -101,7 +54,7 @@
         <div class="feature">
           <div class="feature-content">
             <h2 class="feature-tag">Search</h2>
-            <h1>구매를 원하는<br />상품을 검색하세요</h1>
+            <h1>구매를 원하는<span class="feature-line-break"<br /></span>상품을 검색하세요</h1>
             <p class="feature-description">
               구매하고 싶은 물품은 검색해서
               <br />쉽게 찾아보세요
@@ -144,15 +97,10 @@
     <footer>
       <div>©codeit - 2024</div>
       <div id="footerMenu">
-        <!-- 클릭 시 약관 및 FAQ 페이지로 이동. privacy.html과 faq.html 파일을 생성해 임시 페이지를 만들어 주세요. -->
         <a href="privacy.html">Privacy Policy</a>
         <a href="faq.html">FAQ</a>
       </div>
       <div id="socialMedia">
-        <!--
-          target="_blank" 속성값을 넣어주어 링크가 새로운 탭에서 열리도록 했어요.
-          새 창에서 하이퍼링크를 열 때에는 보안상 취약점 또는 퍼포먼스 이슈가 발생할 수 있기 때문에 rel="noopener noreferrer" 속성값을 함께 넣어주는 경우가 많습니다.
-        -->
         <a
           href="https://www.facebook.com/"
           target="_blank"

--- a/login.html
+++ b/login.html
@@ -11,19 +11,15 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="styles/form.css" />
   </head>
 
   <body>
-    <div class="container">
-      <div class="home-button">
-        <a href="/"
-          ><img
-            src="images/logo/panda-market-logo.png"
-            alt="판다마켓 홈"
-            width="396"
-        /></a>      
-      </div>
+    <div class="form-container">
+      <a href="/" class = "home-button">
+        <img src="images/logo/panda-market-logo.png" alt="판다마켓 홈" 
+      /></a>  
+          
       <form>
         <div class="input-item">
           <label for="email">이메일</label>

--- a/login.html
+++ b/login.html
@@ -15,39 +15,44 @@
   </head>
 
   <body>
-    <div class="login-header">
-      <a href="/"
-        ><img
-          src="images/logo/panda-market-logo.png"
-          alt="판다마켓 홈"
-          width="396"
-      /></a>      
-    </div>
-    <form>
-      <div class="login-input">
-        <label for "email">이메일</label>
+    <div class="container">
+      <div class="home-button">
+        <a href="/"
+          ><img
+            src="images/logo/panda-market-logo.png"
+            alt="판다마켓 홈"
+            width="396"
+        /></a>      
+      </div>
+      <form>
+        <div class="input-item">
+          <label for="email">이메일</label>
           <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
-      </div>
-      <div class="login-input">
-        <label for "password">비밀번호</label>
-          <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
-      </div>
-      <button class="login-pill-button">로그인</button>
-      <div class="social-logins">
-        <span>간편 로그인하기</span>
-        <div class="social-logins-logo">
-          <a href= "https://www.google.com/">
-            <img src="images/social/google-logo.png" alt="구글로고" width="42px">
-          </a>
-          <a href="https://www.kakaocorp.com/page/">
-            <img src="images/social/kakaotalk-logo.png" alt="카카오톡 로고" width="42px">
-          </a>
         </div>
-      </div>
-      <div class="login-bottom">
-        <span>판다마켓이 처음이신가요?</span>
-        <a href="/signup.html">회원가입</a>
-      </div>
-    </form>
+        <div class="input-item">
+          <label for="password">비밀번호</label>
+          <div class="password-input">
+            <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
+            <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
+          </div>
+        </div>
+        <button class="login-pill-button">로그인</button>
+        <div class="social-logins">
+          <span>간편 로그인하기</span>
+          <div class="social-logo">
+            <a href= "https://www.google.com/">
+              <img src="images/social/google-logo.png" alt="구글로고" width="42px">
+            </a>
+            <a href="https://www.kakaocorp.com/page/">
+              <img src="images/social/kakaotalk-logo.png" alt="카카오톡 로고" width="42px">
+            </a>
+          </div>
+        </div>
+        <div class="container-bottom">
+          <span>판다마켓이 처음이신가요?</span>
+          <a href="signup.html">회원가입</a>
+        </div>
+      </form>
+    </div>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -11,59 +11,54 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
     />
-    <link rel="stylesheet" href="styles/global.css" />
+    <link rel="stylesheet" href="styles/form.css" />
   </head>
 
   <body>
-    <div class="container">
-        <div class="home-button">
-            <a href="/"
-              ><img
-                src="images/logo/panda-market-logo.png"
-                alt="판다마켓 홈"
-                width="396"
-            /></a>      
-        </div>
-        <form>
-            <div class="input-item">
-                <label for="email">이메일</label>
-                <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
-            </div> 
-            <div class="input-item">
-                <label for="nickname">닉네임</label>
-                <input id="nickname" name="nickname" type="text" placeholder="닉네임을 입력해주세요">
-            </div>
-            <div class="input-item">
-                <label for="password">비밀번호</label>
-                <div class="password-input">
-                  <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
-                  <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
-                </div>
-              </div>          
-              <div class="input-item">
-                <label for="password-repeat">비밀번호</label>
-                <div class="password-input">
-                  <input id="password-repeat" name="password-repeat" type="password" placeholder="비밀번호를 다시 한 번 입력해 주세요">
-                  <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
-                </div>
-              </div>
-        </form>
-        <button type= "submit" class="login-pill-button">회원가입</button>
-        <div class="social-logins">
-            <span>간편 로그인하기</span>
-            <div class="social-logo">
-              <a href= "https://www.google.com/">
-                <img src="images/social/google-logo.png" alt="구글로고" width="42px">
-              </a>
-              <a href="https://www.kakaocorp.com/page/">
-                <img src="images/social/kakaotalk-logo.png" alt="카카오톡 로고" width="42px">
-              </a>
-            </div>   
-        </div>
-        <div class="container-bottom">
-            <span>이미 회원이신가요?</span>
-            <a href="/login.html">로그인</a>
+    <div class="form-container">
+      <a href="/" class="home-button">
+        <img src="images/logo/panda-market-logo.png" alt="판다마켓 홈"
+      /></a>      
+      <form>
+          <div class="input-item">
+              <label for="email">이메일</label>
+              <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
+          </div> 
+          <div class="input-item">
+              <label for="nickname">닉네임</label>
+              <input id="nickname" name="nickname" type="text" placeholder="닉네임을 입력해주세요">
           </div>
+          <div class="input-item">
+              <label for="password">비밀번호</label>
+              <div class="password-input">
+                <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
+                <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
+              </div>
+            </div>          
+            <div class="input-item">
+              <label for="password-repeat">비밀번호</label>
+              <div class="password-input">
+                <input id="password-repeat" name="password-repeat" type="password" placeholder="비밀번호를 다시 한 번 입력해 주세요">
+                <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
+              </div>
+            </div>
+      </form>
+      <button type= "submit" class="login-pill-button">회원가입</button>
+      <div class="social-logins">
+          <span>간편 로그인하기</span>
+          <div class="social-logo">
+            <a href= "https://www.google.com/">
+              <img src="images/social/google-logo.png" alt="구글로고" width="42px">
+            </a>
+            <a href="https://www.kakaocorp.com/page/">
+              <img src="images/social/kakaotalk-logo.png" alt="카카오톡 로고" width="42px">
+            </a>
+          </div>   
+      </div>
+      <div class="container-bottom">
+          <span>이미 회원이신가요?</span>
+          <a href="/login.html">로그인</a>
+        </div>
     </div>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>판다마켓 - 로그인</title>
+    <title>판다마켓 - 회원가입</title>
     <link rel="icon" href="images/logo/favicon.ico" />
     <link
       rel="stylesheet"
@@ -16,7 +16,7 @@
 
   <body>
     <div class="container">
-        <div class="login-header">
+        <div class="home-button">
             <a href="/"
               ><img
                 src="images/logo/panda-market-logo.png"
@@ -25,22 +25,22 @@
             /></a>      
         </div>
         <form>
-            <div class="login-input">
+            <div class="input-item">
                 <label for="email">이메일</label>
                 <input id="email" name="email" type="email" placeholder="이메일을 입력해 주세요">
             </div> 
-            <div class="login-input">
+            <div class="input-item">
                 <label for="nickname">닉네임</label>
                 <input id="nickname" name="nickname" type="text" placeholder="닉네임을 입력해주세요">
             </div>
-            <div class="login-input">
+            <div class="input-item">
                 <label for="password">비밀번호</label>
                 <div class="password-input">
                   <input id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요">
                   <img src="/images/logo/password.png" alt="비밀번호" class="password-image">
                 </div>
               </div>          
-              <div class="login-input">
+              <div class="input-item">
                 <label for="password-repeat">비밀번호</label>
                 <div class="password-input">
                   <input id="password-repeat" name="password-repeat" type="password" placeholder="비밀번호를 다시 한 번 입력해 주세요">
@@ -48,10 +48,10 @@
                 </div>
               </div>
         </form>
-        <button class="login-pill-button">회원가입</button>
+        <button type= "submit" class="login-pill-button">회원가입</button>
         <div class="social-logins">
             <span>간편 로그인하기</span>
-            <div class="social-logins-logo">
+            <div class="social-logo">
               <a href= "https://www.google.com/">
                 <img src="images/social/google-logo.png" alt="구글로고" width="42px">
               </a>
@@ -60,7 +60,7 @@
               </a>
             </div>   
         </div>
-        <div class="login-bottom">
+        <div class="container-bottom">
             <span>이미 회원이신가요?</span>
             <a href="/login.html">로그인</a>
           </div>

--- a/styles/form.css
+++ b/styles/form.css
@@ -40,6 +40,11 @@ input {
     width: 100%;
 }
 
+.input::placeholder {
+    font-size: 16px;
+    color: #9CA3AF;
+}
+
 .login-pill-button {
     padding: 16px 124px;
     border-radius: 40px;
@@ -66,6 +71,7 @@ input {
     position: absolute;
     right: 30px;
     cursor: pointer;
+    width: 24px;
 }
 
 .social-logins {
@@ -106,9 +112,8 @@ input {
     }
 
     .home-button {
-        width: 396px;
+        width: 400px;
         margin-top: 48px;
         margin-bottom: 48px;
     }
 }
-

--- a/styles/form.css
+++ b/styles/form.css
@@ -1,0 +1,114 @@
+.form-container {
+    margin: 0 auto;
+    padding: 0 16px;
+    max-width: 400px;
+}
+  
+.home-button {
+    display: block;
+    width: 198px;
+    margin: 0 auto;
+    margin-top: 24px;
+    margin-bottom: 24px;
+}
+
+.home-button img {
+    width: 100%;
+}
+
+.input-item {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 24px;
+}
+
+label {
+    display: block;
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 17px;
+}
+
+input {
+    border-radius: 12px;
+    border: none;
+    background-color: #F3F4F6;
+    padding: 16px 24px;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px;
+    width: 100%;
+}
+
+.login-pill-button {
+    padding: 16px 124px;
+    border-radius: 40px;
+    background-color: #9CA3AF;
+    width: 100%;
+    font-size: 20px;
+    text-align: center;
+    font-weight: 600;
+    color: #FFFFFF;
+    border: none;
+}
+
+.login-pill-button:focus {
+    background-color: #3692ff;
+}
+
+.password-input {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.password-image {
+    position: absolute;
+    right: 30px;
+    cursor: pointer;
+}
+
+.social-logins {
+    background-color: #E6F2FF;
+    margin: 24px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 8px;
+    padding: 16px 23px;
+}
+
+.social-login-container h3 {
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.social-logo {
+    display: flex;
+    gap: 16px;
+}
+
+.container-bottom {
+    font-size: 15px;
+    font-weight: 500;
+    text-align: center;
+    color: #1F2937;
+}
+
+.container-bottom > a {
+    text-decoration: underline;
+    color: #3182F6;
+}
+
+@media (min-width: 768px) {
+    .form-container {
+        max-width: 640px;
+    }
+
+    .home-button {
+        width: 396px;
+        margin-top: 48px;
+        margin-bottom: 48px;
+    }
+}
+

--- a/styles/global.css
+++ b/styles/global.css
@@ -108,5 +108,23 @@ button {
   display: none;
 }
 
+@media (min-width: 768px) {
+  header {
+    padding: 0 24px;
+  }
 
+  .wrapper {
+    padding: 0 24px;
+  }
+
+  .pill-button {
+    font-weight: 700;
+    font-size: 20px;
+    padding: 16px 120px;
+  }
+
+  footer {
+    padding: 32px 104px 108px 104px;
+  }
+}
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,7 +1,3 @@
-/* 
-  전체 선택자(*) 및 a, button, img 태그에 대한 CSS는 새로운 웹 개발 프로젝트를 시작할 때 전역 스타일에 기본적으로 넣어주면 좋은 내용들입니다. 
-  브라우저 간의 스타일 차이를 최소화하고 예측 가능한 레이아웃을 위해 브라우저 기본 세팅을 일부 리셋해 준다고 생각하면 됩니다. 
-*/
 
 * {
   margin: 0;
@@ -9,7 +5,6 @@
   box-sizing: border-box;
 }
 
-/* 링크가 상위 요소 또는 설정된 기본 텍스트 색상과 동일하게 표현되길 원한다면 a 태그에 명시적으로 color: inherit을 지정해 줘야 합니다. */
 a {
   text-decoration: none;
   color: inherit;
@@ -23,36 +18,28 @@ button {
   cursor: pointer;
 }
 
-/* 
-  - 이미지는 기본적으로 inline 요소로 취급되기 때문에 텍스트의 baseline에 맞춰서 정렬됩니다. 
-    브라우저가 이미지를 텍스트와 같은 라인에 배치할 때 g, j, p 등 아래로 치우치는 알파벳의 descender 공간을 예약해 놓기 때문에 이미지와 주변 텍스트 사이에 의도하지 않은 작은 간격이 생기는 경우가 많습니다. 
-    <img> 태그에 vertical-align: bottom;을 설정해 주면 이미지가 텍스트 라인의 가장 아래쪽에 맞춰서 정렬되어, 불필요한 공간 없이 배치할 수 있습니다.
-  - 전역적으로 <img>의 display 유형을 inline이 아닌 block으로 바꿔 해당 이슈를 해결하는 경우도 있습니다.
-*/
 img {
   vertical-align: bottom;
 }
 
-/* 
-  프로젝트 전체에 일관된 텍스트 스타일을 적용합니다. 
-  word-break: keep-all 속성을 사용하면 띄어쓰기를 기준으로 줄바꿈하도록 설정하여 어절 기반의 한국어 특성에 적합한 읽기 편한 레이아웃을 제공할 수 있습니다.
-*/
 body {
   color: #374151;
   word-break: keep-all;
   font-family: "Pretendard", sans-serif;
 }
 
-/* 여러 요소가 나란히 배열되어 있을 때는 티가 나지 않아 보여도 항상 잊지 말고 display: flex; align-items: center;로 세로 중앙 정렬을 맞춰주세요. */
 header {
   width: 100%;
   height: 70px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 200px;
+  padding: 0 16px;
   background-color: #ffffff;
   border-bottom: 1px solid #dfdfdf;
+  position: fixed;
+  top: 0;
+  left: 0;
 }
 
 footer {
@@ -61,7 +48,8 @@ footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 32px 200px 108px 200px;
+  flex-wrap: wrap;
+  padding: 32px;
   font-size: 16px;
 }
 
@@ -76,7 +64,6 @@ footer {
   gap: 12px;
 }
 
-/* 요소의 최대 너비를 1200px로 제한하고, 요소가 그보다 큰 경우에는 가로 중앙 정렬해 주는 inner container */
 .wrapper {
   max-width: 1200px;
   margin: 0 auto;
@@ -90,7 +77,6 @@ h1 {
   letter-spacing: 0.02em;
 }
 
-/* 위에서 스타일링해준 <button> 태그와 달리 버튼 모양이지만 <a> 태그를 사용한 class='button' 요소들을 지칭하는 부분이니 혼동하지 않도록 주의하세요. */
 .button {
   background-color: #3692ff;
   color: #ffffff;
@@ -99,10 +85,6 @@ h1 {
   justify-content: center;
 }
 
-/* 
-  가상 클래스(pseudo-class)를 사용해 특정 상태에 맞는 스타일을 적용하세요. 
-  버튼 역할을 하는 요소에는 hover 또는 disabled 시의 스타일을 지정해 주는 것이 사용자 경험에 도움이 됩니다. 
-*/
 .button:hover {
   background-color: #1967d6;
 }
@@ -117,11 +99,6 @@ h1 {
   pointer-events: none;
 }
 
-/* 
-  - 알약 모양의 버튼을 'pill button'이라고 부릅니다. 
-  - border-radius에 큰 값을 넣어주면 모서리가 원형으로 둥글려지는 효과가 있습니다. 
-  - 고정된 width나 height을 부여하는 것보다 내부 콘텐츠에 padding을 적용해서 요소의 전체 크기를 유동적으로 조정하는 방법이 반응형 웹 디자인과 접근성(accessibility) 측면에서 더 적합합니다.
-*/
 .pill-button {
   font-size: 20px;
   font-weight: 700;
@@ -129,20 +106,33 @@ h1 {
   padding: 16px 124px;
 }
 
-.login-container {
+.container {
   margin: 0 auto;
   width: 640px;
 }
 
-.login-header {
+.home-button {
   text-align: center;
   margin: 60px 0 40px;
 }
 
-.login-input {
+.input-item {
   display: flex;
   flex-direction: column;
   margin-bottom: 24px;
+}
+
+.password-input {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.password-image {
+  position: absolute;
+  right: 24px;
+  cursor: pointer;
+  width: 24px;
 }
 
 label {
@@ -159,6 +149,7 @@ input {
   font-size: 16px;
   font-weight: 400;
   line-height: 24px;
+  width: 100%;
 }
 
 .login-pill-button {
@@ -186,12 +177,12 @@ input {
   padding: 16px 23px;
 }
 
-.social-logins-logo {
+.social-logo {
   display: flex;
   gap: 16px;
 }
 
-.login-bottom {
+.container-bottom {
   font-size: 15px;
   font-weight: 500;
   color: #1F2937;
@@ -199,7 +190,8 @@ input {
   text-align: center;
 }
 
-.login-bottom > a {
+.container-bottom > a {
   text-decoration: underline;
   color: #3182F6;
 }
+

--- a/styles/global.css
+++ b/styles/global.css
@@ -128,3 +128,16 @@ button {
   }
 }
 
+@media (min-width: 1200px) {
+  header {
+    padding: 0 200px;
+  }
+
+  .feature-line-break {
+    display: inline;
+  }
+
+  footer {
+    padding: 32px 200px;
+  }
+}

--- a/styles/global.css
+++ b/styles/global.css
@@ -5,23 +5,6 @@
   box-sizing: border-box;
 }
 
-a {
-  text-decoration: none;
-  color: inherit;
-}
-
-button {
-  background: none;
-  border: none;
-  outline: none;
-  box-shadow: none;
-  cursor: pointer;
-}
-
-img {
-  vertical-align: bottom;
-}
-
 body {
   color: #374151;
   word-break: keep-all;
@@ -42,6 +25,10 @@ header {
   left: 0;
 }
 
+main {
+  margin-top: 70px;
+}
+
 footer {
   background-color: #111827;
   color: #9ca3af;
@@ -55,8 +42,8 @@ footer {
 
 #footerMenu {
   display: flex;
-  gap: 30px;
   color: #e5e7eb;
+  gap: 30px;
 }
 
 #socialMedia {
@@ -64,17 +51,28 @@ footer {
   gap: 12px;
 }
 
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+img {
+  vertical-align: bottom;
+}
+
 .wrapper {
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
+  padding: 0 16px;
 }
 
-h1 {
-  font-size: 40px;
-  font-weight: 700;
-  line-height: 56px;
-  letter-spacing: 0.02em;
+button {
+  background: none;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  cursor: pointer;
 }
 
 .button {
@@ -100,98 +98,15 @@ h1 {
 }
 
 .pill-button {
-  font-size: 20px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 600;
   border-radius: 999px;
   padding: 16px 124px;
 }
 
-.container {
-  margin: 0 auto;
-  width: 640px;
+.feature-line-break {
+  display: none;
 }
 
-.home-button {
-  text-align: center;
-  margin: 60px 0 40px;
-}
 
-.input-item {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 24px;
-}
-
-.password-input {
-  display: flex;
-  align-items: center;
-  position: relative;
-}
-
-.password-image {
-  position: absolute;
-  right: 24px;
-  cursor: pointer;
-  width: 24px;
-}
-
-label {
-  font-size: 18px;
-  font-weight: 700;
-  margin-bottom: 17px;
-}
-
-input {
-  border-radius: 12px;
-  border: none;
-  background-color: #F3F4F6;
-  padding: 16px 24px;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 24px;
-  width: 100%;
-}
-
-.login-pill-button {
-  padding: 16px 124px;
-  border-radius: 40px;
-  background-color: #9CA3AF;
-  width: 100%;
-  font-size: 20px;
-  text-align: center;
-  font-weight: 600;
-  color: #FFFFFF;
-}
-
-.login-pill-button:hover {
-  background-color: #3692ff;
-}
-
-.social-logins {
-  background-color: #E6F2FF;
-  margin: 24px 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 8px;
-  padding: 16px 23px;
-}
-
-.social-logo {
-  display: flex;
-  gap: 16px;
-}
-
-.container-bottom {
-  font-size: 15px;
-  font-weight: 500;
-  color: #1F2937;
-  margin-right: 4px;
-  text-align: center;
-}
-
-.container-bottom > a {
-  text-decoration: underline;
-  color: #3182F6;
-}
 

--- a/styles/home.css
+++ b/styles/home.css
@@ -1,68 +1,81 @@
 .banner {
   background-color: #cfe5ff;
   height: 540px;
-  display: flex;
-  align-items: center;
+  text-align: center;
   background-repeat: no-repeat;
-  background-position: 80% bottom;
-  background-size: 55%;
+  background-position: bottom;
+  background-size: 130%;
+}
+
+.banner h1 {
+  font-size: 32px;
+  font-weight: 700;
+  padding-top: 48px;
+  padding-bottom: 18px;
 }
 
 #hero {
   background-image: url("../images/home/hero-image.png");
 }
 
-#features {
-  padding-bottom: 138px;
-}
-
 #bottomBanner {
   background-image: url("../images/home/bottom-banner-image.png");
 }
 
-/* 버튼 등의 요소에 고정된 width나 height을 부여하는 것보다 내부 콘텐츠에 padding을 적용해서 요소의 전체 크기를 유동적으로 조정하는 방법이 반응형 웹 디자인과 접근성(accessibility) 측면에서 더 적합합니다. */
 #loginLinkButton {
   font-size: 16px;
   font-weight: 600;
   border-radius: 8px;
-  padding: 11.5px 23px;
+  padding: 14.5px 43px;
 }
 
-/* banner 요소 내의 pill-button을 선택해 스타일 적용. ID 선택자 대신 이렇게 캐스캐이딩을 활용하는 방법은 특정 컨텍스트 내에서만 스타일을 적용하고자 할 때 유용해요. */
+#features {
+  padding-top: 51px;
+}
+
 .banner .pill-button {
   margin-top: 32px;
 }
 
-/* flex 요소에서는 gap 속성을 사용해 자식 요소 사이의 간격을 조정할 수 있어요. */
-.feature {
-  padding: 138px 0;
-  display: flex;
-  align-items: center;
-  gap: 5%;
+#features {
+  padding-top: 51px;
 }
 
-/* pseudo-selector인 nth-child(2)를 통해 feature 클래스를 가진 요소 중 두 번째 아이템에만 다른 스타일을 적용했어요. */
+.feature {
+  margin-bottom: 64px;
+}
+
+.feature img {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
 .feature:nth-child(2) {
   text-align: right;
 }
 
-/* flex: 1을 통해 부모 요소인 feature의 남은 공간을 모두 차지하도록 설정할 수 있어요. */
 .feature-content {
   flex: 1;
 }
 
-.feature-tag {
-  color: #3692ff;
-  font-size: 18px;
-  line-height: 25px;
+.feature-content h1 {
+  font-size: 24px;
   font-weight: 700;
-  margin-bottom: 12px;
+}
+
+.feature-content h2 {
+  color: #3692ff;
+  font-weight: 700;
+  font-size: 16px;
+  margin-bottom: 8px;
 }
 
 .feature-description {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 500;
   line-height: 120%;
   letter-spacing: 0.08em;
   margin-top: 24px;
 }
+
+

--- a/styles/home.css
+++ b/styles/home.css
@@ -111,3 +111,31 @@
     line-height: 19.2px;
   }
 }
+
+@media (min-width: 1200px) {
+  .banner {
+    display: flex;
+    align-items: center;
+    background-size: 50%;
+    text-align: left;
+  }
+
+  #features {
+    padding: 138px 0;
+  }
+
+  .feature {
+    display: flex;
+    align-items: center;
+    gap: 5%;
+    margin-bottom: 134px;
+  }
+
+  .feature:nth-child(2) {
+    flex-direction: row-reverse;
+  }
+
+  .feature img {
+    width: 50%;
+  }
+}

--- a/styles/home.css
+++ b/styles/home.css
@@ -78,4 +78,36 @@
   margin-top: 24px;
 }
 
+@media (min-width: 768px) {
+  .banner {
+    background-size: 100%;
+  }
 
+  .banner h1 {
+    font-size: 40px;
+    padding-top: 84px;
+    padding-bottom: 24px;
+    line-height: 44.8px;
+  }
+
+  #features {
+    padding-top: 24px;
+    padding-bottom: 16px;
+  }
+
+  .feature-content h2 {
+    font-size: 16px;
+    margin-bottom: 12px;
+    line-height: 22.4px;
+  }
+
+  .feature-content h1 {
+    font-size: 24px;
+    line-height: 33.6px;
+  }
+
+  .feature-description {
+    font-size: 16px;
+    line-height: 19.2px;
+  }
+}


### PR DESCRIPTION
## 요구사항

### 기본

랜딩페이지
- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

로그인, 회원가입 페이지 공통
- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화

- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.

## 주요 변경사항

- login과 signup에 해당하는 css파일을 만들어 따로 분리했습니다.

## 스크린샷


## 멘토에게

-  login과 singup페이지에서 이메일과 닉네임에 해당하는 input 길이가 다른 input에 비해 길어 전체적으로 정렬이 되어있지 않은데요, 
- 'form.css'에서 모든 input의 값을 한꺼번에 적용했는데, 왜 길이가 다른지 궁금합니다. 
https://6606bf21d2b5acf626a8c973--luxury-pasca-1df018.netlify.app/