### PR TITLE
[김지윤] Sprint4

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "singleQuote": true,
+  "singleQuote": false,
   "semi": true,
   "useTabs": false,
   "tabWidth": 2

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -65,6 +65,22 @@ function validateNickname() {
   }
 }
 
+// Password Visible 토글 버튼 (event handler)
+function togglePassword(input) {
+  const passwordInput = document.getElementById(input);
+  const isPassword = passwordInput.getAttribute("type") === "password";
+  passwordInput.setAttribute("type", isPassword ? "text" : "password");
+
+  const icon = passwordInput.nextElementSibling.querySelector("img");
+
+  if (icon) {
+    icon.src = isPassword
+      ? "images/icon/eye-visible.svg"
+      : "images/icon/eye-invisible.svg";
+    icon.alt = isPassword ? "비밀번호 표시" : "비밀번호 숨김";
+  }
+}
+
 // Form 전송 핸들러
 function submitForm(formId, redirectUrl) {
   const form = document.querySelector(`#${formId}`);

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,70 @@
+const emailInput = document.querySelector("#email");
+const nicknameInput = document.querySelector("#nickname");
+const passwordInput = document.querySelector("#password");
+
+// 에러 요소 아이디 수집 & 에러 스타일 설정
+function setError(input, errorMessageId, isError) {
+  const error = document.querySelector(`#${errorMessageId}`);
+  if (isError === true) {
+    error.style.display = "block";
+    input.style.border = "1px solid #f74747";
+    input.setAttribute("aria-invalid", "true");
+  } else if (isError === false) {
+    error.style.display = "none";
+    input.style.border = "none";
+    input.removeAttribute("aria-invalid");
+  }
+}
+
+// E-mail 값 검증 (event handler)
+function validateEmail() {
+  const emailValue = emailInput.value.trim();
+  setError(emailInput, "emailEmptyError", false);
+  setError(emailInput, "emailInvalidError", false);
+
+  if (!emailValue) {
+    setError(emailInput, "emailEmptyError", true);
+  } else if (
+    !(() => {
+      const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+      return emailRegex.test(emailValue);
+    })
+  ) {
+    setError(emailInput, "emailInvalidError", true);
+  }
+}
+
+// Password 값 검증 (event handler)
+function validatePassword() {
+  setError(passwordInput, "passwordEmptyError", false);
+  setError(passwordInput, "passwordInvalidError", false);
+
+  if (!passwordInput.value.trim()) {
+    setError(passwordInput, "passwordEmptyError", true);
+  } else if (passwordInput.value.trim().length < 8) {
+    setError(passwordInput, "passwordInvalidError", true);
+  }
+}
+
+// Form 전송 핸들러
+function submitFormHandler(formId, redirectUrl) {
+  const form = document.querySelector(`#${formId}`);
+
+  if (!form) return;
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    validateEmail();
+    validatePassword();
+
+    if (!document.querySelector('.error-message[style="display: block;"]')) {
+      window.location.href = redirectUrl;
+    }
+  });
+}
+
+// Event Handlers 등록
+emailInput.addEventListener("focusout", validateEmail);
+passwordInput.addEventListener("focusout", validatePassword);
+
+submitFormHandler("signInForm", "/items");

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -47,17 +47,23 @@ function validatePassword() {
 }
 
 // Form 전송 핸들러
-function submitFormHandler(formId, redirectUrl) {
+function submitForm(formId, redirectUrl) {
   const form = document.querySelector(`#${formId}`);
+  const submitButton = document.querySelector(".submit-form-btn");
 
   if (!form) return;
 
-  form.addEventListener("submit", function (e) {
+  form.addEventListener("submit", (e) => {
     e.preventDefault();
     validateEmail();
     validatePassword();
 
-    if (!document.querySelector('.error-message[style="display: block;"]')) {
+    const isError = document.querySelector(
+      '.error-message[style="display: block;"]'
+    );
+
+    if (!isError) {
+      submitButton.style.backgroundColor = "#3692ff";
       window.location.href = redirectUrl;
     }
   });
@@ -67,4 +73,4 @@ function submitFormHandler(formId, redirectUrl) {
 emailInput.addEventListener("focusout", validateEmail);
 passwordInput.addEventListener("focusout", validatePassword);
 
-submitFormHandler("signInForm", "/items");
+submitForm("signInForm", "/items");

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,6 +1,7 @@
 const emailInput = document.querySelector("#email");
 const nicknameInput = document.querySelector("#nickname");
 const passwordInput = document.querySelector("#password");
+const passwordInputConfirm = document.querySelector("#passwordConfirm");
 
 // 에러 요소 아이디 수집 & 에러 스타일 설정
 function setError(input, errorMessageId, isError) {
@@ -46,6 +47,24 @@ function validatePassword() {
   }
 }
 
+// Password 일치 검증 (event handler)
+function validatePasswordConfrim() {
+  setError(passwordInputConfirm, "passwordConfirmError", false);
+
+  if (passwordInput.value.trim() !== passwordInputConfirm.value.trim()) {
+    setError(passwordInputConfirm, "passwordConfirmError", true);
+  }
+}
+
+// Nickname 값 검증 (event handler)
+function validateNickname() {
+  setError(nicknameInput, "nicknameEmptyError", false);
+
+  if (!nicknameInput.value.trim()) {
+    setError(nicknameInput, "nicknameEmptyError", true);
+  }
+}
+
 // Form 전송 핸들러
 function submitForm(formId, redirectUrl) {
   const form = document.querySelector(`#${formId}`);
@@ -57,12 +76,12 @@ function submitForm(formId, redirectUrl) {
     e.preventDefault();
     validateEmail();
     validatePassword();
+    if (formId === "signUpForm") {
+      validateNickname();
+      validatePasswordConfrim();
+    }
 
-    const isError = document.querySelector(
-      '.error-message[style="display: block;"]'
-    );
-
-    if (!isError) {
+    if (!document.querySelector('.error-message[style="display: block;"]')) {
       submitButton.style.backgroundColor = "#3692ff";
       window.location.href = redirectUrl;
     }
@@ -72,5 +91,12 @@ function submitForm(formId, redirectUrl) {
 // Event Handlers 등록
 emailInput.addEventListener("focusout", validateEmail);
 passwordInput.addEventListener("focusout", validatePassword);
+if (passwordInputConfirm) {
+  passwordInputConfirm.addEventListener("focusout", validatePasswordConfrim);
+}
+if (nicknameInput) {
+  nicknameInput.addEventListener("focusout", validateNickname);
+}
 
 submitForm("signInForm", "/items");
+submitForm("signUpForm", "/signin");

--- a/signin.html
+++ b/signin.html
@@ -53,11 +53,13 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
             />
-            <img
-              src="images/icon/eye-invisible.svg"
-              alt="비밀번호 숨기기"
+            <button
+              type="button"
               class="toggle-password"
-            />
+              onclick="togglePassword('password')"
+            >
+              <img src="images/icon/eye-invisible.svg" alt="비밀번호 숨기기" />
+            </button>
           </div>
           <span id="passwordEmptyError" class="error-message"
             >비밀번호를 입력해주세요.</span
@@ -94,6 +96,6 @@
         판다마켓이 처음인가요? <a href="signup.html">회원가입</a>
       </div>
     </div>
-    <script type="module" src="scripts/auth.js"></script>
+    <script src="scripts/auth.js"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -27,7 +27,7 @@
         </a>
       </div>
 
-      <form method="post">
+      <form id="signInForm" method="post">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -36,6 +36,12 @@
             type="email"
             placeholder="이메일을 입력해주세요"
           />
+          <span id="emailEmptyError" class="error-message"
+            >이메일을 입력해주세요.</span
+          >
+          <span id="emailInvalidError" class="error-message"
+            >잘못된 이메일 형식입니다</span
+          >
         </div>
 
         <div class="input-item">
@@ -53,6 +59,12 @@
               class="toggle-password"
             />
           </div>
+          <span id="passwordEmptyError" class="error-message"
+            >비밀번호를 입력해주세요.</span
+          >
+          <span id="passwordInvalidError" class="error-message"
+            >비밀번호를 8자 이상 입력해주세요.</span
+          >
         </div>
 
         <button type="submit" class="btn-primary submit-form-btn">
@@ -82,5 +94,6 @@
         판다마켓이 처음인가요? <a href="signup.html">회원가입</a>
       </div>
     </div>
+    <script type="module" src="scripts/auth.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -64,11 +64,13 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
             />
-            <img
-              src="images/icon/eye-invisible.svg"
-              alt="비밀번호 숨기기"
+            <button
+              type="button"
               class="toggle-password"
-            />
+              onclick="togglePassword('password')"
+            >
+              <img src="images/icon/eye-invisible.svg" alt="비밀번호 숨기기" />
+            </button>
           </div>
           <span id="passwordEmptyError" class="error-message"
             >비밀번호를 입력해주세요.</span
@@ -86,11 +88,13 @@
               type="password"
               placeholder="비밀번호를 다시 한 번 입력해 주세요"
             />
-            <img
-              src="images/icon/eye-invisible.svg"
-              alt="비밀번호 숨기기"
+            <button
+              type="button"
               class="toggle-password"
-            />
+              onclick="togglePassword('passwordConfirm')"
+            >
+              <img src="images/icon/eye-invisible.svg" alt="비밀번호 숨기기" />
+            </button>
           </div>
           <span id="passwordConfirmError" class="error-message"
             >비밀번호가 일치하지 않습니다.</span
@@ -124,6 +128,6 @@
         이미 회원이신가요? <a href="signin.html">로그인</a>
       </div>
     </div>
-    <script type="module" src="scripts/auth.js"></script>
+    <script src="scripts/auth.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -27,7 +27,7 @@
         </a>
       </div>
 
-      <form method="post">
+      <form id="signUpForm" method="post">
         <div class="input-item">
           <label for="email">이메일</label>
           <input
@@ -36,6 +36,12 @@
             type="email"
             placeholder="이메일을 입력해주세요"
           />
+          <span id="emailEmptyError" class="error-message"
+            >이메일을 입력해주세요.</span
+          >
+          <span id="emailInvalidError" class="error-message"
+            >잘못된 이메일 형식입니다</span
+          >
         </div>
         <div class="input-item">
           <label for="nickname">닉네임</label>
@@ -45,6 +51,9 @@
             type="text"
             placeholder="닉네임을 입력해주세요"
           />
+          <span id="nicknameEmptyError" class="error-message"
+            >닉네임을 입력해주세요.</span
+          >
         </div>
         <div class="input-item">
           <label for="password">비밀번호</label>
@@ -61,6 +70,12 @@
               class="toggle-password"
             />
           </div>
+          <span id="passwordEmptyError" class="error-message"
+            >비밀번호를 입력해주세요.</span
+          >
+          <span id="passwordInvalidError" class="error-message"
+            >비밀번호를 8자 이상 입력해주세요.</span
+          >
         </div>
         <div class="input-item">
           <label for="passwordConfrim">비밀번호 확인</label>
@@ -77,6 +92,9 @@
               class="toggle-password"
             />
           </div>
+          <span id="passwordConfirmError" class="error-message"
+            >비밀번호가 일치하지 않습니다.</span
+          >
         </div>
 
         <button type="submit" class="btn-primary submit-form-btn">
@@ -106,5 +124,6 @@
         이미 회원이신가요? <a href="signin.html">로그인</a>
       </div>
     </div>
+    <script type="module" src="scripts/auth.js"></script>
   </body>
 </html>

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -47,6 +47,7 @@ input:focus {
   position: absolute;
   right: 24px;
   cursor: pointer;
+  background-color: inherit;
 }
 
 /* Form Submit Button */

--- a/styles/auth.css
+++ b/styles/auth.css
@@ -57,6 +57,7 @@ input:focus {
   font-size: 20px;
   font-weight: 600;
   line-height: 24px;
+  background-color: var(--gray-200);
 }
 
 /* Social Login Container */
@@ -82,6 +83,15 @@ input:focus {
 .social-login-btns {
   display: flex;
   gap: 16px;
+}
+
+.error-message {
+  display: none;
+  color: var(--red);
+  line-height: 18px;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 0 0 16px;
 }
 
 /* Auth Swith */

--- a/styles/global.css
+++ b/styles/global.css
@@ -20,10 +20,11 @@
 
 * {
   box-sizing: border-box;
+  border: none;
 }
 
 body {
-  font-family: 'Pretendard', sans-serif;
+  font-family: "Pretendard", sans-serif;
   margin: 0 auto;
 }
 
@@ -119,8 +120,8 @@ footer {
   .footer-wrap {
     display: grid;
     grid-template-areas:
-      'menu sns'
-      'copy .';
+      "menu sns"
+      "copy .";
     row-gap: 60px;
   }
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -15,6 +15,7 @@
 
   /* Primary color */
   --white: #ffffff;
+  --red: #f74747;
 }
 
 * {

--- a/styles/home.css
+++ b/styles/home.css
@@ -108,10 +108,6 @@
     font-size: 24px;
   }
 
-  .promotion-title h2 br {
-    display: none;
-  }
-
   .btn-items {
     display: block;
     margin: 0 auto;


### PR DESCRIPTION
## 요구사항

### [배포 사이트](https://660eef2cf7b3cf37c2acb709--darling-pony-3d0d68.netlify.app/)

### 기본

#### 로그인
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다

#### 회원가입
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다


### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항
JS 스크립트 추가: scripts/

## 스크린샷
![22](https://github.com/codeit-bootcamp-frontend/6-Sprint-Mission/assets/64190056/79456f0a-498b-4f3e-90bf-a6c44590bd18)
![222](https://github.com/codeit-bootcamp-frontend/6-Sprint-Mission/assets/64190056/b2c41dcd-e641-40b0-8723-82f8b2f6168c)



## 멘토에게

