### PR TITLE
[고한샘] Sprint4

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -35,10 +35,10 @@ form {
 
 .input {
   width: 100%;
-  height: 93px;
+
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: px;
 }
 input {
   width: 100%;
@@ -59,6 +59,23 @@ label {
   font-family: Pretendard;
   font-weight: 700;
   font-size: 18px;
+  margin-bottom: 16px;
+}
+
+.error {
+  display: block;
+  color: #f74747;
+  font-size: 15px;
+  font-weight: 600;
+  padding-left: 16px;
+  margin: 0px;
+}
+
+.error_border {
+  border: 1px solid #f74747 !important;
+}
+.hide {
+  display: none;
 }
 
 form button {

--- a/login.html
+++ b/login.html
@@ -35,7 +35,7 @@
                     <p class="error error_pwd_undefined hide">비밀번호를 입력해주세요.</p>
                 </div>
                 <div>
-                    <button type="submit">로그인</button>
+                    <button class="login_submit_button" type="submit">로그인</button>
                 </div>
             </form>
             <div class="easy_login">

--- a/login.html
+++ b/login.html
@@ -21,12 +21,12 @@
             <form action="" id="login_form">
                 <div class="input">
                     <label for="email">이메일</label>
-                    <input type="email" name="email" placeholder="이메일을 입력해주세요">
+                    <input type="email" id="email" placeholder="이메일을 입력해주세요">
                 </div>
                 <div class="input">
                     <label for="pwd">비밀번호</label>
                     <div class="pwd">
-                        <input type="password" name="pwd" placeholder="비밀번호를 입력해주세요">
+                        <input type="password" id="pwd" placeholder="비밀번호를 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
                     </div>    
                 </div>

--- a/login.html
+++ b/login.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>로그인</title>
     <link rel="stylesheet" as="style" crossorigin
-        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" >
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">
     <link rel="icon" href="images/logo/favicon.ico">
 
     <link rel="stylesheet" href="./css/login.css">
@@ -21,14 +21,18 @@
             <form action="" id="login_form">
                 <div class="input">
                     <label for="email">이메일</label>
-                    <input type="email" id="email" placeholder="이메일을 입력해주세요">
+                    <input type="email" id="email" class="" placeholder="이메일을 입력해주세요">
+                    <p class="error error_email_wrong hide">잘못된 이메일입니다.</p>
+                    <p class="error error_email_undefined hide">이메일을 입력해주세요.</p>
                 </div>
                 <div class="input">
                     <label for="pwd">비밀번호</label>
                     <div class="pwd">
-                        <input type="password" id="pwd" placeholder="비밀번호를 입력해주세요">
+                        <input type="password" id="pwd" class="" placeholder="비밀번호를 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
-                    </div>    
+                    </div>
+                    <p class="error error_pwd_wrong hide">비밀번호를 8자 이상 입력해주세요.</p>
+                    <p class="error error_pwd_undefined hide">비밀번호를 입력해주세요.</p>
                 </div>
                 <div>
                     <button type="submit">로그인</button>
@@ -47,6 +51,7 @@
             </div>
         </div>
     </main>
+    <script src="./login.js"></script>
 </body>
 
 </html>

--- a/login.js
+++ b/login.js
@@ -4,6 +4,7 @@ const errorEmailWrong = document.querySelector(".error_email_wrong");
 const errorEmailUndefined = document.querySelector(".error_email_undefined");
 const errorPwdWrong = document.querySelector(".error_pwd_wrong");
 const errorPwdUndefined = document.querySelector(".error_pwd_undefined");
+const loginSubmitButton = document.querySelector(".login_submit_button");
 
 function emailCheck(email_address) {
   const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
@@ -47,3 +48,18 @@ pwdInput.addEventListener("focusout", (event) => {
     }
   }
 });
+
+function handlerActive() {
+  if (
+    emailCheck(emailInput.value) &&
+    pwdInput.value &&
+    pwdInput.value.length >= 8
+  ) {
+    loginSubmitButton.disabled = false;
+  } else {
+    loginSubmitButton.disabled = true;
+  }
+}
+loginSubmitButton.disabled = true;
+emailInput.addEventListener("keyup", handlerActive);
+pwdInput.addEventListener("keyup", handlerActive);

--- a/login.js
+++ b/login.js
@@ -1,0 +1,49 @@
+const emailInput = document.getElementById("email");
+const pwdInput = document.getElementById("pwd");
+const errorEmailWrong = document.querySelector(".error_email_wrong");
+const errorEmailUndefined = document.querySelector(".error_email_undefined");
+const errorPwdWrong = document.querySelector(".error_pwd_wrong");
+const errorPwdUndefined = document.querySelector(".error_pwd_undefined");
+
+function emailCheck(email_address) {
+  const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  if (!email_regex.test(email_address)) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+emailInput.addEventListener("focusout", (event) => {
+  if (event.target.value == "") {
+    errorEmailUndefined.classList.remove("hide");
+    errorEmailWrong.classList.add("hide");
+  } else {
+    if (emailCheck(event.target.value)) {
+      errorEmailUndefined.classList.add("hide");
+      event.target.classList.remove("error_border");
+      errorEmailWrong.classList.add("hide");
+    } else {
+      errorEmailUndefined.classList.add("hide");
+      event.target.classList.add("error_border");
+      errorEmailWrong.classList.remove("hide");
+    }
+  }
+});
+
+pwdInput.addEventListener("focusout", (event) => {
+  if (event.target.value == "") {
+    errorPwdUndefined.classList.remove("hide");
+    errorPwdWrong.classList.add("hide");
+  } else {
+    if (event.target.value.length >= 8) {
+      errorPwdUndefined.classList.add("hide");
+      event.target.classList.remove("error_border");
+      errorPwdWrong.classList.add("hide");
+    } else {
+      errorPwdUndefined.classList.add("hide");
+      event.target.classList.add("error_border");
+      errorPwdWrong.classList.remove("hide");
+    }
+  }
+});

--- a/signup.html
+++ b/signup.html
@@ -21,23 +21,23 @@
             <form action="" id="login_form">
                 <div class="input">
                     <label for="email">이메일</label>
-                    <input type="email" name="email" placeholder="이메일을 입력해주세요">
+                    <input type="email" id="email" placeholder="이메일을 입력해주세요">
                 </div>
                 <div class="input">
                     <label for="nickname">닉네임</label>
-                    <input type="text" name="nickname" placeholder="닉네임을 입력해주세요">
+                    <input type="text" id="nickname" placeholder="닉네임을 입력해주세요">
                 </div>
                 <div class="input">
                     <label for="pwd">비밀번호</label>
                     <div class="pwd">
-                        <input type="password" name="pwd" placeholder="비밀번호를 입력해주세요">
+                        <input type="password" id="pwd" placeholder="비밀번호를 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
                     </div>    
                 </div>
                 <div class="input">
                     <label for="pwd_check ">비밀번호 확인</label>
                     <div class="pwd">
-                        <input type="password" name="pwd_check" placeholder="비밀번호를 다시 한번 입력해주세요">
+                        <input type="password" id="pwd_check" placeholder="비밀번호를 다시 한번 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
                     </div>    
                 </div>

--- a/signup.html
+++ b/signup.html
@@ -48,7 +48,7 @@
                     <p class="error error_pwd_check hide">비밀번호가 일치하지 않습니다.</p>
                 </div>
                 <div>
-                    <button type="submit">회원가입</button>
+                    <button class="signup_submit_button" type="submit">회원가입</button>
                 </div>
             </form>
             <div class="easy_login">

--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>회원가입</title>
     <link rel="stylesheet" as="style" crossorigin
-        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" >
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">
     <link rel="icon" href="images/logo/favicon.ico">
 
     <link rel="stylesheet" href="./css/login.css">
@@ -22,24 +22,30 @@
                 <div class="input">
                     <label for="email">이메일</label>
                     <input type="email" id="email" placeholder="이메일을 입력해주세요">
+                    <p class="error error_email_wrong hide">잘못된 이메일입니다.</p>
+                    <p class="error error_email_undefined hide">이메일을 입력해주세요.</p>
                 </div>
                 <div class="input">
                     <label for="nickname">닉네임</label>
                     <input type="text" id="nickname" placeholder="닉네임을 입력해주세요">
+                    <p class="error error_nickname hide">닉네임을 입력해주세요.</p>
                 </div>
                 <div class="input">
                     <label for="pwd">비밀번호</label>
                     <div class="pwd">
                         <input type="password" id="pwd" placeholder="비밀번호를 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
-                    </div>    
+                    </div>
+                    <p class="error error_pwd_wrong hide">비밀번호를 8자 이상 입력해주세요.</p>
+                    <p class="error error_pwd_undefined hide">비밀번호를 입력해주세요.</p>
                 </div>
                 <div class="input">
                     <label for="pwd_check ">비밀번호 확인</label>
                     <div class="pwd">
                         <input type="password" id="pwd_check" placeholder="비밀번호를 다시 한번 입력해주세요">
                         <img class="mark_unvisible" src="./images/mark_unvisible.svg" alt="비밀번호 보이기">
-                    </div>    
+                    </div>
+                    <p class="error error_pwd_check hide">비밀번호가 일치하지 않습니다.</p>
                 </div>
                 <div>
                     <button type="submit">회원가입</button>
@@ -58,6 +64,7 @@
             </div>
         </div>
     </main>
+    <script src="./signup.js"></script>
 </body>
 
 </html>

--- a/signup.js
+++ b/signup.js
@@ -8,6 +8,7 @@ const errorPwdWrong = document.querySelector(".error_pwd_wrong");
 const errorPwdUndefined = document.querySelector(".error_pwd_undefined");
 const errorPwdCheck = document.querySelector(".error_pwd_check");
 const errorNickname = document.querySelector(".error_nickname");
+const signupSubmitButton = document.querySelector(".signup_submit_button");
 
 function emailCheck(email_address) {
   const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
@@ -71,3 +72,22 @@ pwdCheckInput.addEventListener("focusout", (event) => {
     event.target.classList.add("error_border");
   }
 });
+
+function handlerActive() {
+  if (
+    emailCheck(emailInput.value) &&
+    nicknameInput.value &&
+    pwdInput.value &&
+    pwdInput.value.length >= 8 &&
+    pwdInput.value === pwdCheckInput.value
+  ) {
+    signupSubmitButton.disabled = false;
+  } else {
+    signupSubmitButton.disabled = true;
+  }
+}
+signupSubmitButton.disabled = true;
+emailInput.addEventListener("keyup", handlerActive);
+nicknameInput.addEventListener("keyup", handlerActive);
+pwdInput.addEventListener("keyup", handlerActive);
+pwdCheckInput.addEventListener("keyup", handlerActive);

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,73 @@
+const emailInput = document.getElementById("email");
+const nicknameInput = document.getElementById("nickname");
+const pwdInput = document.getElementById("pwd");
+const pwdCheckInput = document.getElementById("pwd_check");
+const errorEmailWrong = document.querySelector(".error_email_wrong");
+const errorEmailUndefined = document.querySelector(".error_email_undefined");
+const errorPwdWrong = document.querySelector(".error_pwd_wrong");
+const errorPwdUndefined = document.querySelector(".error_pwd_undefined");
+const errorPwdCheck = document.querySelector(".error_pwd_check");
+const errorNickname = document.querySelector(".error_nickname");
+
+function emailCheck(email_address) {
+  const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  if (!email_regex.test(email_address)) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+emailInput.addEventListener("focusout", (event) => {
+  if (event.target.value == "") {
+    errorEmailUndefined.classList.remove("hide");
+    errorEmailWrong.classList.add("hide");
+  } else {
+    if (emailCheck(event.target.value)) {
+      errorEmailUndefined.classList.add("hide");
+      event.target.classList.remove("error_border");
+      errorEmailWrong.classList.add("hide");
+    } else {
+      errorEmailUndefined.classList.add("hide");
+      event.target.classList.add("error_border");
+      errorEmailWrong.classList.remove("hide");
+    }
+  }
+});
+
+nicknameInput.addEventListener("focusout", (event) => {
+  if (event.target.value == "") {
+    errorNickname.classList.remove("hide");
+    event.target.classList.add("error_border");
+  } else {
+    errorNickname.classList.add("hide");
+    event.target.classList.remove("error_border");
+  }
+});
+
+pwdInput.addEventListener("focusout", (event) => {
+  if (event.target.value == "") {
+    errorPwdUndefined.classList.remove("hide");
+    errorPwdWrong.classList.add("hide");
+  } else {
+    if (event.target.value.length >= 8) {
+      errorPwdUndefined.classList.add("hide");
+      event.target.classList.remove("error_border");
+      errorPwdWrong.classList.add("hide");
+    } else {
+      errorPwdUndefined.classList.add("hide");
+      event.target.classList.add("error_border");
+      errorPwdWrong.classList.remove("hide");
+    }
+  }
+});
+
+pwdCheckInput.addEventListener("focusout", (event) => {
+  if (pwdInput.value === pwdCheckInput.value) {
+    errorPwdCheck.classList.add("hide");
+    event.target.classList.remove("error_border");
+  } else {
+    errorPwdCheck.classList.remove("hide");
+    event.target.classList.add("error_border");
+  }
+});


### PR DESCRIPTION
## 요구사항

### 기본

- ## 로그인

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [ ] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다


- ## 회원가입

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [ ] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다

- []

### 심화

- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [ ] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다

## 주요 변경사항
-

## 배포 사이트
-https://pandacodeit.netlify.app/
![image](이미지url)

## 멘토에게

- 미완성입니다...
- 지금 막히는 부분이 활성화된 로그인 버튼을 누르면 이동을 안하고 url를 보면 제출도 안되는거 같아요.
- 오늘내일 중으로 수정작업 해보겠습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
