### PR TITLE
[임진조] Sprint4

### DIFF
--- a/pandamarket/index.html
+++ b/pandamarket/index.html
@@ -16,14 +16,13 @@
 
   <body>
     <header>
-          <div class="header-container">
+          <div class="header-inner">
             <a id="logo" href="./"></a>
             <a href="./signin.html" class="login-button">로그인</a> 
           </div>
         </header>
-
     <main>
-        <div id="topBanner-img" class="topBanner">
+        <div id="topBanner-panda" class="topBanner">
           <div class="topBanner-content">
             <h1>일상의 모든 물건을<br>
                 거래해 보세요</h1>
@@ -31,7 +30,7 @@
           </div>
         </div>
 
-        <div class="main-container">
+        <div class="main-inner">
           <div class="main1">
             <img src="./images/Img_home_01.png" alt="home_01">
             <div class="hot-item">
@@ -78,7 +77,7 @@
           </div>
         </div>
 
-        <div id="bottomBanner-img" class="bottomBanner">
+        <div id="bottomBanner-panda" class="bottomBanner">
           <div class="bottomBanner-content">
             <h1>
               믿을 수 있는<br>
@@ -89,10 +88,10 @@
     </main>
 
     <footer>
-          <div class="footer-container">
+          <div class="footer-inner">
             <div class="footer-codeit">©codeit - 2024</div>
             <div class="privacy">
-              <a href="/privacy"><div>Privacy Privacy</div></a>
+              <a href="/privacy"><div>Privacy Policy</div></a>
               <a href="/faq"><div>FAQ</div></a>
             </div>
             

--- a/pandamarket/item.html
+++ b/pandamarket/item.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>item</title>
+</head>
+<body>
+  <h1>item</h1> 
+</body>
+</html>

--- a/pandamarket/scripts/authPageHandler.js
+++ b/pandamarket/scripts/authPageHandler.js
@@ -1,0 +1,78 @@
+function togglePasswordVisibility(event) {
+  const eyeIconParent = event.target.parentNode;
+  const passwordInput = eyeIconParent.previousElementSibling;
+  if (passwordInput.type === 'password') {
+    passwordInput.type = 'text';
+    eyeIconParent.innerHTML = '<img src="./images/open_eye.png" alt="비밀번호 보이기">';
+  } else {
+    passwordInput.type = 'password';
+    eyeIconParent.innerHTML = '<img src="./images/close_eye.png" alt="비밀번호 숨기기">';
+  }
+}
+
+function validateEmail(email) {
+  const regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/; 
+  return regex.test(email);
+}
+
+function validatePasswordLength(password) {
+  if (password.length < 8) {
+    return false;
+  }
+  return true;
+}
+
+function generateErrorMessage(errorMessage, targetElement) {
+  const hasClassName = targetElement.querySelector('.errorMessage') != null;
+
+  if (!hasClassName) {
+    const newDiv = document.createElement('div');
+    newDiv.classList.add('errorMessage');
+    newDiv.textContent = `${errorMessage}`;
+    newDiv.style.margin = "0px 16px 24px";
+    newDiv.style.color = "#f74747";
+    newDiv.style.fontSize = "15px";
+    newDiv.style.fontWeight = "600";
+    targetElement.appendChild(newDiv);
+  } else {
+    removeErrorMessage(targetElement);
+    generateErrorMessage(errorMessage, targetElement);
+  }
+}
+
+function removeErrorMessage(targetElement) {
+  const hasClassName = targetElement.querySelector('.errorMessage');
+  if (hasClassName) {
+    hasClassName.remove();
+  }
+}
+
+function validateAuthForm(event, path) {
+  //focusout발생
+  event.preventDefault();
+  const submitButton = document.querySelector('.submit-button');
+  const focusout = new Event('focusout');
+  const inputs = document.getElementsByTagName('input');
+  [...inputs].forEach((input) => input.dispatchEvent(focusout));
+  // form 제출 전 확인
+  const errorMessage = document.querySelectorAll('.errorMessage');
+  if (errorMessage.length === 0) {
+    const form = submitButton.closest('form');
+    window.location.href = `./${path}`;
+    // form.submit();
+  }
+}
+
+function inputErrorStyle(event) {
+  event.target.style.outline = "2px solid #f74747";
+};
+
+function inputSuccessStyle(event) {
+  event.target.style.outline = 0;
+};
+
+function inputFocusInStyle(event) {
+  event.target.style.outline = "2px solid #3692ff";
+}
+
+export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail,generateErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm};

--- a/pandamarket/scripts/authPageHandler.js
+++ b/pandamarket/scripts/authPageHandler.js
@@ -22,22 +22,26 @@ function validatePasswordLength(password) {
   return true;
 }
 
-function generateErrorMessage(errorMessage, targetParentElement) {
+function addErrorMessage(errorMessage, targetParentElement) {
   const hasClassName = targetParentElement.querySelector('.errorMessage') != null;
+  const errorInput = targetParentElement.querySelector('input');
   if (!hasClassName) {
+    errorInput.classList.add('error');
     const newDiv = document.createElement('div');
     newDiv.classList.add('errorMessage');
     newDiv.textContent = `${errorMessage}`;
     targetParentElement.appendChild(newDiv);
   } else {
     removeErrorMessage(targetParentElement);
-    generateErrorMessage(errorMessage, targetParentElement);
+    addErrorMessage(errorMessage, targetParentElement);
   }
 }
 
 function removeErrorMessage(targetParentElement) {
+  const errorInput = targetParentElement.querySelector('input');
   const hasClassName = targetParentElement.querySelector('.errorMessage');
   if (hasClassName) {
+    errorInput.classList.remove('error');
     hasClassName.remove();
   }
 }
@@ -50,11 +54,22 @@ function validateAuthForm(event, path) {
   const inputs = document.getElementsByTagName('input');
   [...inputs].forEach((input) => input.dispatchEvent(focusout));
   // form 제출 전 확인
-  const errorMessage = document.querySelectorAll('.errorMessage');
-  if (errorMessage.length === 0) {
-    const form = submitButton.closest('form');
+  const errorInput = document.querySelectorAll('input');
+  if (errorInput.length === 0) {
     window.location.href = `./${path}`;
+    // const form = submitButton.closest('form');
     // form.submit();
+  }
+}
+// 요구사항 충족 시 버튼 활성화
+function formCheck() {
+  const errorInputs = document.querySelectorAll('.error');
+  const submitBtn = document.querySelector('.submit-button');
+  console.log(errorInputs.length);
+  if (errorInputs.length === 0) {
+    submitBtn.style.backgroundColor = "#3691ff";
+  } else {
+    submitBtn.style.backgroundColor = "#9ca3af";
   }
 }
 
@@ -71,4 +86,4 @@ function inputFocusInStyle(event) {
   event.target.style.outline = "2px solid #3692ff";
 }
 
-export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail,generateErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm}
+export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail, addErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm, formCheck}

--- a/pandamarket/scripts/authPageHandler.js
+++ b/pandamarket/scripts/authPageHandler.js
@@ -47,25 +47,27 @@ function removeErrorMessage(targetParentElement) {
 }
 
 function validateAuthForm(event, path) {
-  //focusout발생
   event.preventDefault();
-  const submitButton = document.querySelector('.submit-button');
+  // focusout 발생
+  // const submitButton = document.querySelector('.submit-button');
   const focusout = new Event('focusout');
-  const inputs = document.getElementsByTagName('input');
+  const inputs = document.querySelectorAll('input');
   [...inputs].forEach((input) => input.dispatchEvent(focusout));
   // form 제출 전 확인
-  const errorInput = document.querySelectorAll('input');
-  if (errorInput.length === 0) {
+  const errorInputs = document.querySelectorAll('.error');
+  if (errorInputs.length === 0) {
     window.location.href = `./${path}`;
     // const form = submitButton.closest('form');
     // form.submit();
+  } else {
+    console.log(errorInputs);
+    errorInputs[0].focus();
   }
 }
 // 요구사항 충족 시 버튼 활성화
 function formCheck() {
   const errorInputs = document.querySelectorAll('.error');
   const submitBtn = document.querySelector('.submit-button');
-  console.log(errorInputs.length);
   if (errorInputs.length === 0) {
     submitBtn.style.backgroundColor = "#3691ff";
   } else {

--- a/pandamarket/scripts/authPageHandler.js
+++ b/pandamarket/scripts/authPageHandler.js
@@ -15,18 +15,23 @@ function validateEmail(email) {
   return regex.test(email);
 }
 
-function validatePasswordLength(password) {
+function validatePassword(password) {
   if (password.length < 8) {
     return false;
   }
   return true;
 }
 
+function validatePasswordVerify(password, passwordVerify) {
+  if (password === passwordVerify && password !== '') {
+    return true;
+  }
+  return false;
+}
+
 function addErrorMessage(errorMessage, targetParentElement) {
   const hasClassName = targetParentElement.querySelector('.errorMessage') != null;
-  const errorInput = targetParentElement.querySelector('input');
   if (!hasClassName) {
-    errorInput.classList.add('error');
     const newDiv = document.createElement('div');
     newDiv.classList.add('errorMessage');
     newDiv.textContent = `${errorMessage}`;
@@ -38,43 +43,50 @@ function addErrorMessage(errorMessage, targetParentElement) {
 }
 
 function removeErrorMessage(targetParentElement) {
-  const errorInput = targetParentElement.querySelector('input');
   const hasClassName = targetParentElement.querySelector('.errorMessage');
   if (hasClassName) {
-    errorInput.classList.remove('error');
     hasClassName.remove();
   }
 }
 
-function validateAuthForm(event, path) {
-  event.preventDefault();
-  // focusout 발생
-  // const submitButton = document.querySelector('.submit-button');
-  const focusout = new Event('focusout');
-  const inputs = document.querySelectorAll('input');
-  [...inputs].forEach((input) => input.dispatchEvent(focusout));
-  // form 제출 전 확인
-  const errorInputs = document.querySelectorAll('.error');
-  if (errorInputs.length === 0) {
-    window.location.href = `./${path}`;
-    // const form = submitButton.closest('form');
-    // form.submit();
-  } else {
-    console.log(errorInputs);
-    errorInputs[0].focus();
-  }
-}
-// 요구사항 충족 시 버튼 활성화
+// focusout 발생후 모든 input조사,확인 후 버튼 색상 변경, 제출가능 불가능 리턴
 function formCheck() {
-  const errorInputs = document.querySelectorAll('.error');
-  const submitBtn = document.querySelector('.submit-button');
-  if (errorInputs.length === 0) {
-    submitBtn.style.backgroundColor = "#3691ff";
-  } else {
-    submitBtn.style.backgroundColor = "#9ca3af";
-  }
+    let isFormValid = true;
+    const submitBtn = document.querySelector('.submit-button');
+    const inputs = document.querySelectorAll('input');
+    const password = document.getElementById('password');
+    for(const input of inputs) {
+      switch(input.id) {
+        case 'email':
+          isFormValid = validateEmail(input.value);
+          break;
+        case 'password':
+          isFormValid = validatePassword(input.value);
+          break;
+        case 'nickname':
+          if (input.value === '') {
+            isFormValid = false;
+          } else {
+            isFormValid = true;
+          }
+          break;
+        case 'password-verify':
+          isFormValid = validatePasswordVerify(password.value, input.value);
+          break;
+      }
+      if (isFormValid === false) {
+        break;
+      }
+    };
+    if (isFormValid) {
+      console.log('활성');
+      submitBtn.style.backgroundColor = "#3691ff";
+      return true;
+    } else {
+      submitBtn.style.backgroundColor = "#9ca3af";
+      return false;
+    }
 }
-
 
 function inputErrorStyle(event) {
   event.target.style.outline = "2px solid #f74747";
@@ -88,4 +100,4 @@ function inputFocusInStyle(event) {
   event.target.style.outline = "2px solid #3692ff";
 }
 
-export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail, addErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm, formCheck}
+export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail, addErrorMessage, removeErrorMessage, validatePassword, formCheck, validatePasswordVerify}

--- a/pandamarket/scripts/authPageHandler.js
+++ b/pandamarket/scripts/authPageHandler.js
@@ -22,26 +22,21 @@ function validatePasswordLength(password) {
   return true;
 }
 
-function generateErrorMessage(errorMessage, targetElement) {
-  const hasClassName = targetElement.querySelector('.errorMessage') != null;
-
+function generateErrorMessage(errorMessage, targetParentElement) {
+  const hasClassName = targetParentElement.querySelector('.errorMessage') != null;
   if (!hasClassName) {
     const newDiv = document.createElement('div');
     newDiv.classList.add('errorMessage');
     newDiv.textContent = `${errorMessage}`;
-    newDiv.style.margin = "0px 16px 24px";
-    newDiv.style.color = "#f74747";
-    newDiv.style.fontSize = "15px";
-    newDiv.style.fontWeight = "600";
-    targetElement.appendChild(newDiv);
+    targetParentElement.appendChild(newDiv);
   } else {
-    removeErrorMessage(targetElement);
-    generateErrorMessage(errorMessage, targetElement);
+    removeErrorMessage(targetParentElement);
+    generateErrorMessage(errorMessage, targetParentElement);
   }
 }
 
-function removeErrorMessage(targetElement) {
-  const hasClassName = targetElement.querySelector('.errorMessage');
+function removeErrorMessage(targetParentElement) {
+  const hasClassName = targetParentElement.querySelector('.errorMessage');
   if (hasClassName) {
     hasClassName.remove();
   }
@@ -63,16 +58,17 @@ function validateAuthForm(event, path) {
   }
 }
 
+
 function inputErrorStyle(event) {
   event.target.style.outline = "2px solid #f74747";
-};
+}
 
 function inputSuccessStyle(event) {
   event.target.style.outline = 0;
-};
+}
 
 function inputFocusInStyle(event) {
   event.target.style.outline = "2px solid #3692ff";
 }
 
-export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail,generateErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm};
+export { togglePasswordVisibility, inputErrorStyle, inputSuccessStyle, inputFocusInStyle, validateEmail,generateErrorMessage, removeErrorMessage, validatePasswordLength, validateAuthForm}

--- a/pandamarket/scripts/signin.js
+++ b/pandamarket/scripts/signin.js
@@ -1,46 +1,48 @@
-import * as authPageHandler from "./authPageHandler.js";
+import * as authHandler from "./authPageHandler.js";
 
 const eyeIcon = document.getElementById('eyeIcon');
-eyeIcon.addEventListener('click', authPageHandler.togglePasswordVisibility);
+eyeIcon.addEventListener('click', authHandler.togglePasswordVisibility);
 // email
-const emailInputFocus = document.getElementById('email-focus');
-emailInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-emailInputFocus.addEventListener('focusout', (event) => {
-  const inputEmail = emailInputFocus.value;
+const emailInput = document.getElementById('email');
+emailInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+emailInput.addEventListener('focusout', (event) => {
+  const inputEmail = emailInput.value;
   const targetElement = event.target.parentElement;
   if (inputEmail.length === 0) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("이메일을 입력해 주세요", targetElement);
-  } else if(!authPageHandler.validateEmail(inputEmail)) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("잘못된 이메일 형식입니다", targetElement);
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("이메일을 입력해 주세요", targetElement);
+  } else if(!authHandler.validateEmail(inputEmail)) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("잘못된 이메일 형식입니다", targetElement);
   } else {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   }
+  authHandler.formCheck();
 });
 // password
-const passwordInputFocus = document.getElementById('password-focus');
-passwordInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-passwordInputFocus.addEventListener('focusout', (event) => {
-  const inputPassword = passwordInputFocus.value;
+const paswordInput = document.getElementById('password');
+paswordInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+paswordInput.addEventListener('focusout', (event) => {
+  const inputPassword = paswordInput.value;
   const targetElement = event.target.parentElement;
   if (inputPassword.length === 0) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("비밀번호를 입력해 주세요", targetElement);
-  } else if (!authPageHandler.validatePasswordLength(inputPassword)) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("비밀번호를 입력해 주세요", targetElement);
+  } else if (!authHandler.validatePasswordLength(inputPassword)) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
   } else {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   }
+  authHandler.formCheck();
 });
 
 // focus 발생, errorMessage체크, submit
 const submitButton = document.querySelector('.submit-button');
 submitButton.addEventListener('click', (event) => {
-  authPageHandler.validateAuthForm(event , "item.html");
+  authHandler.validateAuthForm(event , "item.html");
 });
 
 

--- a/pandamarket/scripts/signin.js
+++ b/pandamarket/scripts/signin.js
@@ -2,47 +2,56 @@ import * as authHandler from "./authPageHandler.js";
 
 const eyeIcon = document.getElementById('eyeIcon');
 eyeIcon.addEventListener('click', authHandler.togglePasswordVisibility);
-// email
-const emailInput = document.getElementById('email');
-emailInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-emailInput.addEventListener('focusout', (event) => {
-  const inputEmail = emailInput.value;
-  const targetElement = event.target.parentElement;
-  if (inputEmail.length === 0) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("이메일을 입력해 주세요", targetElement);
-  } else if(!authHandler.validateEmail(inputEmail)) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("잘못된 이메일 형식입니다", targetElement);
-  } else {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
+
+// dom파싱, 로드된 이후 실행하며 이벤트 위임을 구현해 보자
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('form');
+  form.addEventListener('focusin', authHandler.inputFocusInStyle);
+  form.addEventListener('focusout', handleValidation);
+  // form제출 로직
+  form.addEventListener('submit', function (e) {
+  const focusout = new Event('focusout',{ bubbles:true});
+  const inputs = document.querySelectorAll('input');
+    e.preventDefault();
+    const isFormValid = authHandler.formCheck();
+    if (isFormValid) {
+      window.location.href = './item.html';
+    } else {
+      for(const input of inputs) {
+        input.dispatchEvent(focusout);
+      }
+    }
+  });
+
+  function handleValidation(e) {
+    const target = e.target;
+    let valid = true;
+    let message = "";
+
+    switch(target.id) {
+      case 'email':
+        message = '이메일을 입력해주세요';
+        valid = authHandler.validateEmail(target.value);
+        if (target.value !== '') {
+        message = '잘못된 이메일 형식입니다';
+        }
+        break;
+      case 'password':
+        message = '비밀번호를 입력해주세요';
+        valid = authHandler.validatePassword(target.value);
+        if (target.value !== '') {
+          message = '비밀번호를 8자 이상 입력해주세요';
+        }
+        break;
+    }
+    if (!valid) {
+      authHandler.inputErrorStyle(e);
+      authHandler.addErrorMessage(message, target.parentElement);
+      authHandler.formCheck();
+    } else {
+      authHandler.removeErrorMessage(target.parentElement);
+      authHandler.inputSuccessStyle(e);
+      authHandler.formCheck();
+    } 
   }
-  authHandler.formCheck();
 });
-// password
-const paswordInput = document.getElementById('password');
-paswordInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-paswordInput.addEventListener('focusout', (event) => {
-  const inputPassword = paswordInput.value;
-  const targetElement = event.target.parentElement;
-  if (inputPassword.length === 0) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("비밀번호를 입력해 주세요", targetElement);
-  } else if (!authHandler.validatePasswordLength(inputPassword)) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
-  } else {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
-  }
-  authHandler.formCheck();
-});
-
-// focus 발생, errorMessage체크, submit
-const submitButton = document.querySelector('.submit-button');
-submitButton.addEventListener('click', (event) => {
-  authHandler.validateAuthForm(event , "item.html");
-});
-
-

--- a/pandamarket/scripts/signin.js
+++ b/pandamarket/scripts/signin.js
@@ -2,52 +2,42 @@ import * as authPageHandler from "./authPageHandler.js";
 
 const eyeIcon = document.getElementById('eyeIcon');
 eyeIcon.addEventListener('click', authPageHandler.togglePasswordVisibility);
-
+// email
 const emailInputFocus = document.getElementById('email-focus');
-
 emailInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-
 emailInputFocus.addEventListener('focusout', (event) => {
   const inputEmail = emailInputFocus.value;
   const targetElement = event.target.parentElement;
   if (inputEmail.length === 0) {
     authPageHandler.inputErrorStyle(event);
-    // 이메일을 입력해 주세요 생성
     authPageHandler.generateErrorMessage("이메일을 입력해 주세요", targetElement);
   } else if(!authPageHandler.validateEmail(inputEmail)) {
-    // 잘못된 이메일 형식입니다로 변경
     authPageHandler.inputErrorStyle(event);
     authPageHandler.generateErrorMessage("잘못된 이메일 형식입니다", targetElement);
   } else {
     authPageHandler.inputSuccessStyle(event);
-    // 이메일을 입력해 주세요 or 잘못된 이메일 형식입니다 삭제
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
-
+// password
 const passwordInputFocus = document.getElementById('password-focus');
-
 passwordInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-
 passwordInputFocus.addEventListener('focusout', (event) => {
   const inputPassword = passwordInputFocus.value;
   const targetElement = event.target.parentElement;
   if (inputPassword.length === 0) {
     authPageHandler.inputErrorStyle(event);
-    // 비밀번호를 입력해 주세요 생성
     authPageHandler.generateErrorMessage("비밀번호를 입력해 주세요", targetElement);
   } else if (!authPageHandler.validatePasswordLength(inputPassword)) {
     authPageHandler.inputErrorStyle(event);
-    // 비밀번호를 8자 이상 입력해 주세요로 변경
     authPageHandler.generateErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
   } else {
     authPageHandler.inputSuccessStyle(event);
-    // 비밀번호를 입력해주세요 or 비밀번호를 8자 이상 입력해 주세요 삭제
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
 
-// 버튼 눌렀을 때 form이 나가지 않고 먼저 error가 있는지 전부 실행해봄
+// focus 발생, errorMessage체크, submit
 const submitButton = document.querySelector('.submit-button');
 submitButton.addEventListener('click', (event) => {
   authPageHandler.validateAuthForm(event , "item.html");

--- a/pandamarket/scripts/signup.js
+++ b/pandamarket/scripts/signup.js
@@ -1,8 +1,11 @@
 import * as authPageHandler from "./authPageHandler.js";
 
 const eyeIcon = document.getElementById('eyeIcon');
+const eyeIconVerify = document.getElementById('eyeIcon-verify');
 eyeIcon.addEventListener('click', authPageHandler.togglePasswordVisibility);
+eyeIconVerify.addEventListener('click', authPageHandler.togglePasswordVisibility);
 
+// emailinput
 const emailInputFocus = document.getElementById('email-focus');
 
 emailInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
@@ -24,7 +27,21 @@ emailInputFocus.addEventListener('focusout', (event) => {
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
-
+// nickname
+const nicknameInputFocus = document.getElementById('nickname-focus');
+nicknameInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
+nicknameInputFocus.addEventListener('focusout', (event) => {
+  const inputNickname = nicknameInputFocus.value;
+  const targetElement = event.target.parentElement;
+  if (inputNickname.length === 0) {
+    authPageHandler.inputErrorStyle(event);
+    authPageHandler.generateErrorMessage("닉네임을 입력해주세요", targetElement);
+  } else {
+    authPageHandler.inputSuccessStyle(event);
+    authPageHandler.removeErrorMessage(targetElement);
+  }
+});
+//passwordinput
 const passwordInputFocus = document.getElementById('password-focus');
 
 passwordInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
@@ -46,11 +63,23 @@ passwordInputFocus.addEventListener('focusout', (event) => {
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
+//password-verify
+const passwordVerifyInputFocus = document.getElementById('password-verify-focus');
+passwordVerifyInputFocus.addEventListener('focusout', (event) => {
+  const inputVerifyPassword = passwordVerifyInputFocus.value;
+  const inputPassword = passwordInputFocus.value;
+  const targetElement = event.target.parentElement;
+  if (inputVerifyPassword === inputPassword) {
+    authPageHandler.inputSuccessStyle(event);
+    authPageHandler.removeErrorMessage(targetElement);
+  } else {
+    authPageHandler.inputErrorStyle(event);
+    authPageHandler.generateErrorMessage("비밀번호가 일치하지 않습니다", targetElement);
+  }
+})
 
 // 버튼 눌렀을 때 form이 나가지 않고 먼저 error가 있는지 전부 실행해봄
 const submitButton = document.querySelector('.submit-button');
 submitButton.addEventListener('click', (event) => {
-  authPageHandler.validateAuthForm(event , "item.html");
+  authPageHandler.validateAuthForm(event, "signin.html")
 });
-
-

--- a/pandamarket/scripts/signup.js
+++ b/pandamarket/scripts/signup.js
@@ -1,76 +1,81 @@
-import * as authPageHandler from "./authPageHandler.js";
+import * as authHandler from "./authPageHandler.js";
 
 const eyeIcon = document.getElementById('eyeIcon');
 const eyeIconVerify = document.getElementById('eyeIcon-verify');
-eyeIcon.addEventListener('click', authPageHandler.togglePasswordVisibility);
-eyeIconVerify.addEventListener('click', authPageHandler.togglePasswordVisibility);
+eyeIcon.addEventListener('click', authHandler.togglePasswordVisibility);
+eyeIconVerify.addEventListener('click', authHandler.togglePasswordVisibility);
 
 // email
-const emailInputFocus = document.getElementById('email-focus');
-emailInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-emailInputFocus.addEventListener('focusout', (event) => {
-  const inputEmail = emailInputFocus.value;
+const emailInput = document.getElementById('email');
+emailInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+emailInput.addEventListener('focusout', (event) => {
+  const Email = emailInput.value;
   const targetElement = event.target.parentElement;
-  if (inputEmail.length === 0) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("이메일을 입력해 주세요", targetElement);
-  } else if(!authPageHandler.validateEmail(inputEmail)) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("잘못된 이메일 형식입니다", targetElement);
+  if (Email.length === 0) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("이메일을 입력해 주세요", targetElement);
+  } else if(!authHandler.validateEmail(Email)) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("잘못된 이메일 형식입니다", targetElement);
   } else {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   }
+  // 버튼 활성화 체크
+  authHandler.formCheck();
 });
 // nickname
-const nicknameInputFocus = document.getElementById('nickname-focus');
-nicknameInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-nicknameInputFocus.addEventListener('focusout', (event) => {
-  const inputNickname = nicknameInputFocus.value;
+const nicknameInput = document.getElementById('nickname');
+nicknameInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+nicknameInput.addEventListener('focusout', (event) => {
+  const Nickname = nicknameInput.value;
   const targetElement = event.target.parentElement;
-  if (inputNickname.length === 0) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("닉네임을 입력해주세요", targetElement);
+  if (Nickname.length === 0) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("닉네임을 입력해주세요", targetElement);
   } else {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   }
+  authHandler.formCheck();
 });
 //password
-const passwordInputFocus = document.getElementById('password-focus');
-passwordInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-passwordInputFocus.addEventListener('focusout', (event) => {
-  const inputPassword = passwordInputFocus.value;
+const passwordInput = document.getElementById('password');
+passwordInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+passwordInput.addEventListener('focusout', (event) => {
+  const Password = passwordInput.value;
   const targetElement = event.target.parentElement;
-  if (inputPassword.length === 0) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("비밀번호를 입력해 주세요", targetElement);
-  } else if (!authPageHandler.validatePasswordLength(inputPassword)) {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
+  if (Password.length === 0) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("비밀번호를 입력해 주세요", targetElement);
+  } else if (!authHandler.validatePasswordLength(Password)) {
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
   } else {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   }
+  authHandler.formCheck();
 });
 //password-verify
-const passwordVerifyInputFocus = document.getElementById('password-verify-focus');
-passwordVerifyInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-passwordVerifyInputFocus.addEventListener('focusout', (event) => {
-  const inputVerifyPassword = passwordVerifyInputFocus.value;
-  const inputPassword = passwordInputFocus.value;
+const passwordVerifyInput = document.getElementById('password-verify');
+passwordVerifyInput.addEventListener('focusin', authHandler.inputFocusInStyle);
+passwordVerifyInput.addEventListener('focusout', (event) => {
+  const verifyPassword = passwordVerifyInput.value;
+  const password = passwordInput.value;
   const targetElement = event.target.parentElement;
-  if (inputVerifyPassword === inputPassword) {
-    authPageHandler.inputSuccessStyle(event);
-    authPageHandler.removeErrorMessage(targetElement);
+  if (verifyPassword === password) {
+    authHandler.inputSuccessStyle(event);
+    authHandler.removeErrorMessage(targetElement);
   } else {
-    authPageHandler.inputErrorStyle(event);
-    authPageHandler.generateErrorMessage("비밀번호가 일치하지 않습니다", targetElement);
+    authHandler.inputErrorStyle(event);
+    authHandler.addErrorMessage("비밀번호가 일치하지 않습니다", targetElement);
   }
+  authHandler.formCheck();
 });
 
 // focus 발생, errorMessage체크, submit
 const submitButton = document.querySelector('.submit-button');
 submitButton.addEventListener('click', (event) => {
-  authPageHandler.validateAuthForm(event, "signin.html")
+  authHandler.validateAuthForm(event, "signin.html")
 });

--- a/pandamarket/scripts/signup.js
+++ b/pandamarket/scripts/signup.js
@@ -5,25 +5,20 @@ const eyeIconVerify = document.getElementById('eyeIcon-verify');
 eyeIcon.addEventListener('click', authPageHandler.togglePasswordVisibility);
 eyeIconVerify.addEventListener('click', authPageHandler.togglePasswordVisibility);
 
-// emailinput
+// email
 const emailInputFocus = document.getElementById('email-focus');
-
 emailInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-
 emailInputFocus.addEventListener('focusout', (event) => {
   const inputEmail = emailInputFocus.value;
   const targetElement = event.target.parentElement;
   if (inputEmail.length === 0) {
     authPageHandler.inputErrorStyle(event);
-    // 이메일을 입력해 주세요 생성
     authPageHandler.generateErrorMessage("이메일을 입력해 주세요", targetElement);
   } else if(!authPageHandler.validateEmail(inputEmail)) {
-    // 잘못된 이메일 형식입니다로 변경
     authPageHandler.inputErrorStyle(event);
     authPageHandler.generateErrorMessage("잘못된 이메일 형식입니다", targetElement);
   } else {
     authPageHandler.inputSuccessStyle(event);
-    // 이메일을 입력해 주세요 or 잘못된 이메일 형식입니다 삭제
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
@@ -41,30 +36,26 @@ nicknameInputFocus.addEventListener('focusout', (event) => {
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
-//passwordinput
+//password
 const passwordInputFocus = document.getElementById('password-focus');
-
 passwordInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
-
 passwordInputFocus.addEventListener('focusout', (event) => {
   const inputPassword = passwordInputFocus.value;
   const targetElement = event.target.parentElement;
   if (inputPassword.length === 0) {
     authPageHandler.inputErrorStyle(event);
-    // 비밀번호를 입력해 주세요 생성
     authPageHandler.generateErrorMessage("비밀번호를 입력해 주세요", targetElement);
   } else if (!authPageHandler.validatePasswordLength(inputPassword)) {
     authPageHandler.inputErrorStyle(event);
-    // 비밀번호를 8자 이상 입력해 주세요로 변경
     authPageHandler.generateErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
   } else {
     authPageHandler.inputSuccessStyle(event);
-    // 비밀번호를 입력해주세요 or 비밀번호를 8자 이상 입력해 주세요 삭제
     authPageHandler.removeErrorMessage(targetElement);
   }
 });
 //password-verify
 const passwordVerifyInputFocus = document.getElementById('password-verify-focus');
+passwordVerifyInputFocus.addEventListener('focusin', authPageHandler.inputFocusInStyle);
 passwordVerifyInputFocus.addEventListener('focusout', (event) => {
   const inputVerifyPassword = passwordVerifyInputFocus.value;
   const inputPassword = passwordInputFocus.value;
@@ -76,9 +67,9 @@ passwordVerifyInputFocus.addEventListener('focusout', (event) => {
     authPageHandler.inputErrorStyle(event);
     authPageHandler.generateErrorMessage("비밀번호가 일치하지 않습니다", targetElement);
   }
-})
+});
 
-// 버튼 눌렀을 때 form이 나가지 않고 먼저 error가 있는지 전부 실행해봄
+// focus 발생, errorMessage체크, submit
 const submitButton = document.querySelector('.submit-button');
 submitButton.addEventListener('click', (event) => {
   authPageHandler.validateAuthForm(event, "signin.html")

--- a/pandamarket/scripts/signup.js
+++ b/pandamarket/scripts/signup.js
@@ -5,77 +5,68 @@ const eyeIconVerify = document.getElementById('eyeIcon-verify');
 eyeIcon.addEventListener('click', authHandler.togglePasswordVisibility);
 eyeIconVerify.addEventListener('click', authHandler.togglePasswordVisibility);
 
-// email
-const emailInput = document.getElementById('email');
-emailInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-emailInput.addEventListener('focusout', (event) => {
-  const Email = emailInput.value;
-  const targetElement = event.target.parentElement;
-  if (Email.length === 0) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("이메일을 입력해 주세요", targetElement);
-  } else if(!authHandler.validateEmail(Email)) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("잘못된 이메일 형식입니다", targetElement);
-  } else {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
-  }
-  // 버튼 활성화 체크
-  authHandler.formCheck();
-});
-// nickname
-const nicknameInput = document.getElementById('nickname');
-nicknameInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-nicknameInput.addEventListener('focusout', (event) => {
-  const Nickname = nicknameInput.value;
-  const targetElement = event.target.parentElement;
-  if (Nickname.length === 0) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("닉네임을 입력해주세요", targetElement);
-  } else {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
-  }
-  authHandler.formCheck();
-});
-//password
-const passwordInput = document.getElementById('password');
-passwordInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-passwordInput.addEventListener('focusout', (event) => {
-  const Password = passwordInput.value;
-  const targetElement = event.target.parentElement;
-  if (Password.length === 0) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("비밀번호를 입력해 주세요", targetElement);
-  } else if (!authHandler.validatePasswordLength(Password)) {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("비밀번호를 8자 이상 입력해 주세요", targetElement);
-  } else {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
-  }
-  authHandler.formCheck();
-});
-//password-verify
-const passwordVerifyInput = document.getElementById('password-verify');
-passwordVerifyInput.addEventListener('focusin', authHandler.inputFocusInStyle);
-passwordVerifyInput.addEventListener('focusout', (event) => {
-  const verifyPassword = passwordVerifyInput.value;
-  const password = passwordInput.value;
-  const targetElement = event.target.parentElement;
-  if (verifyPassword === password) {
-    authHandler.inputSuccessStyle(event);
-    authHandler.removeErrorMessage(targetElement);
-  } else {
-    authHandler.inputErrorStyle(event);
-    authHandler.addErrorMessage("비밀번호가 일치하지 않습니다", targetElement);
-  }
-  authHandler.formCheck();
-});
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('form');
+  const password = document.getElementById('password');
+  form.addEventListener('focusin', authHandler.inputFocusInStyle);
+  form.addEventListener('focusout', handleValidation);
+  // form제출 로직
+  form.addEventListener('submit', function (e) {
+    const focusout = new Event('focusout', {bubbles: true});
+    const inputs = document.querySelectorAll('input');
+    e.preventDefault();
+    const isFormValid = authHandler.formCheck();
+    if (isFormValid) {
+      window.location.href = './signin.html';
+    } else {
+      for (const input of inputs) {
+        input.dispatchEvent(focusout);
+      }
+    }
+  });
 
-// focus 발생, errorMessage체크, submit
-const submitButton = document.querySelector('.submit-button');
-submitButton.addEventListener('click', (event) => {
-  authHandler.validateAuthForm(event, "signin.html")
+  function handleValidation(e) {
+    const target = e.target;
+    let valid = true;
+    let message = "";
+
+    switch(target.id) {
+      case 'email':
+        message = '이메일을 입력해주세요';
+        valid = authHandler.validateEmail(target.value);
+        if (target.value !== '') {
+        message = '잘못된 이메일 형식입니다';
+        }
+        break;
+      case 'password':
+        message = '비밀번호를 입력해주세요';
+        valid = authHandler.validatePassword(target.value);
+        if (target.value !== '') {
+          message = '비밀번호를 8자 이상 입력해주세요';
+        }
+        break;
+      case 'nickname':
+        message = '닉네임을 입력해주세요';
+        if (target.value === '') {
+          valid = false;
+        }
+        break;
+      case 'password-verify':
+        message = '비밀번호를 다시 한번 입력해주세요';
+        valid = authHandler.validatePasswordVerify(password.value, target.value);
+        if (target.value !== '') {
+          message = '비밀번호가 일치하지 않습니다';
+        }
+        break;
+    }
+    if (!valid) {
+      authHandler.inputErrorStyle(e);
+      authHandler.addErrorMessage(message, target.parentElement);
+      authHandler.formCheck();
+    } else {
+      authHandler.removeErrorMessage(target.parentElement);
+      authHandler.inputSuccessStyle(e);
+      authHandler.formCheck();
+    } 
+  }
 });

--- a/pandamarket/signin.html
+++ b/pandamarket/signin.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./styles/signInUp.css">
+    <link rel="stylesheet" href="./styles/authPages.css">
   <title>로그인</title>
   </head>
 <body>
@@ -12,17 +12,17 @@
     <form>
       <div class="form-group">
         <label for="email">이메일</label>
-        <input type="email" id="email" name="email" placeholder="이메일을 입력해주세요" required>
+        <input id="email-focus" type="email" name="email" placeholder="이메일을 입력해주세요">
       </div>
       <div class="form-group">
         <label for="password">비밀번호</label>
         <div class="password-input-container">
-          <input type="password" id="password" name="password" placeholder="비밀번호를 입력해주세요" required>
-          <span id="toggle-password"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
+          <input id="password-focus" type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <span id="eyeIcon"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>
       <div class="form-group">
-        <button class="submit">로그인</button>
+        <button class="submit-button">로그인</button>
       </div>
     </form>
     <div class="OAuth-container">
@@ -37,7 +37,7 @@
     <div class="signup">
       판다마켓이 처음이신가요?<a href="./signup.html">회원가입</a>
     </div>
-    <script src="./scripts/signin.js"></script>
+    <script type="module" src="./scripts/signin.js"></script>
   </div>
 </body>
 </html>

--- a/pandamarket/signin.html
+++ b/pandamarket/signin.html
@@ -12,12 +12,12 @@
     <form>
       <div class="form-group">
         <label for="email">이메일</label>
-        <input id="email-focus" type="email" name="email" placeholder="이메일을 입력해주세요">
+        <input id="email" type="email" name="email" placeholder="이메일을 입력해주세요">
       </div>
       <div class="form-group">
         <label for="password">비밀번호</label>
         <div class="password-input-container">
-          <input id="password-focus" type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <input id="password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
           <span id="eyeIcon"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>

--- a/pandamarket/signup.html
+++ b/pandamarket/signup.html
@@ -12,18 +12,18 @@
     <form>
       <div class="form-group">
         <label for="email">이메일</label>
-        <input id="email-focus" type="email" id="email" name="email" placeholder="이메일을 입력해주세요">
+        <input id="email" type="email" id="email" name="email" placeholder="이메일을 입력해주세요">
       </div>
 
       <div class="form-group">
         <label for="nickname">닉네임</label>
-        <input id="nickname-focus" type="text" name="nickname" placeholder="닉네임을 입력해주세요">
+        <input id="nickname" type="text" name="nickname" placeholder="닉네임을 입력해주세요">
       </div>
 
       <div class="form-group">
         <label for="password">비밀번호</label>
         <div class="password-input-container">
-          <input id="password-focus" type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <input id="password" type="password" name="password" placeholder="비밀번호를 입력해주세요">
           <span id="eyeIcon"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>
@@ -31,7 +31,7 @@
       <div class="form-group">
         <label for="password-verify">비밀번호 확인</label>
         <div class="password-input-container">
-          <input id="password-verify-focus" type="password" name="password-verify" placeholder="비밀번호를 다시 한번 입력해주세요">
+          <input id="password-verify" type="password" name="password-verify" placeholder="비밀번호를 다시 한번 입력해주세요">
           <span id="eyeIcon-verify"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>

--- a/pandamarket/signup.html
+++ b/pandamarket/signup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./styles/signInUp.css">
+    <link rel="stylesheet" href="./styles/authPages.css">
   <title>로그인</title>
   </head>
 <body>
@@ -12,32 +12,32 @@
     <form>
       <div class="form-group">
         <label for="email">이메일</label>
-        <input type="email" id="email" name="email" placeholder="이메일을 입력해주세요" required>
+        <input id="email-focus" type="email" id="email" name="email" placeholder="이메일을 입력해주세요">
       </div>
 
       <div class="form-group">
-        <label for="email">닉네임</label>
-        <input type="text" id="nickname" name="nickname" placeholder="닉네임을 입력해주세요" required>
+        <label for="nickname">닉네임</label>
+        <input id="nickname-focus" type="text" name="nickname" placeholder="닉네임을 입력해주세요">
       </div>
 
       <div class="form-group">
         <label for="password">비밀번호</label>
         <div class="password-input-container">
-          <input type="password" id="password" name="password" placeholder="비밀번호를 입력해주세요" required>
-          <span id="toggle-password"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
+          <input id="password-focus" type="password" name="password" placeholder="비밀번호를 입력해주세요">
+          <span id="eyeIcon"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>
 
       <div class="form-group">
         <label for="password-verify">비밀번호 확인</label>
         <div class="password-input-container">
-          <input type="password" id="password-verify" name="password-verify" placeholder="비밀번호를 다시 한번 입력해주세요" required>
-          <span id="toggle-password-verify"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
+          <input id="password-verify-focus" type="password" name="password-verify" placeholder="비밀번호를 다시 한번 입력해주세요">
+          <span id="eyeIcon-verify"><img src="./images/close_eye.png" alt="비밀번호 보기/숨기기"></span>
         </div>
       </div>
 
       <div class="form-group">
-        <button class="submit">회원가입</button>
+        <button class="submit-button">회원가입</button>
       </div>
     </form>
 
@@ -53,7 +53,7 @@
     <div class="signup">
       판다마켓이 처음이신가요?<a href="./signup.html">회원가입</a>
     </div>
-    <script src="./scripts/signin.js"></script>
+    <script type="module" src="./scripts/signup.js"></script>
   </div>
 </body>
 </html>

--- a/pandamarket/styles/authPages.css
+++ b/pandamarket/styles/authPages.css
@@ -121,6 +121,13 @@ input:focus {
   white-space:nowrap;
 }
 
+.errorMessage {
+  margin: 0 16px 24px;
+  color: #f74747;
+  font-size: 15px;
+  font-weight: 600;
+}
+
 /*mobile */
 @media (min-width: 375px) and (max-width: 767px) {
   .login-container {

--- a/pandamarket/styles/authPages.css
+++ b/pandamarket/styles/authPages.css
@@ -1,47 +1,14 @@
 * {
   margin: 0;
   box-sizing: border-box;
-}
-
-.logo {
-  display: flex;
-  justify-content: center;
-}
-
-.login-container {
-  margin: 60px auto auto;
-  display: flex;
-  flex-direction: column;
-  width: 640px;
-}
-
-.form-group {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-}
-
-.signup {
-  text-align: center;
-  margin-top: 24px;
+  font-family: 'Pretendard';
 }
 
 label {
   color: #1f2937;
-  font-family: 'Pretendard';
   font-weight: 700;
   font-size: 18px;
   line-height: 21.48px;
-}
-
-input::placeholder {
-  text-indent: 24px;
-  color: #9CA3AF;
-  font-family: 'Pretendard';
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
 }
 
 input {
@@ -56,12 +23,56 @@ input {
   border-radius: 12px;
 }
 
+input::placeholder {
+  text-indent: 24px;
+  color: #9ca3af;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+}
+
 input:focus {
   outline: 2px solid #3692ff;
 }
 
-.submit {
-  font-family: 'Pretendard';
+.login-container {
+  width: 640px;
+  margin: 60px auto;
+}
+
+.logo {
+  display: flex;
+  justify-content: center;
+}
+
+.signin-container {
+  margin: 60px auto auto;
+  display: flex;
+  flex-direction: column;
+  width: 640px;
+}
+
+#eyeIcon-verify,
+#eyeIcon {
+  position: absolute;
+  top: 32px;
+  right: 24px;
+  cursor: pointer;
+}
+
+.form-group {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.signup {
+  text-align: center;
+  margin-top: 24px;
+}
+
+.submit-button {
   font-weight: 600;
   font-size: 20px;
   line-height: 24px;
@@ -73,6 +84,7 @@ input:focus {
   color: #ffffff;
 }
 
+
 .OAuth-container {
   border-radius: 8px;
   padding: 16px 23px;
@@ -83,7 +95,6 @@ input:focus {
 }
 
 .OAuth {
-  font-family: 'Pretendard';
   font-weight: 500;
   font-size: 16px;
   display: flex;
@@ -100,18 +111,10 @@ input:focus {
 .password-input-container {
   position: relative;
 }
-#toggle-password-verify,
-#toggle-password {
-  position: absolute;
-  top: 32px;
-  right: 24px;
-  cursor: pointer;
-}
 
 .Oauth_img {
   display: flex;
   gap: 30px;
-  width: ;
 }
 
 .OAuth > div {

--- a/pandamarket/styles/main.css
+++ b/pandamarket/styles/main.css
@@ -41,7 +41,7 @@ footer {
     background-size: 100%;
   }
 
-.main-container {
+.main-inner{
   display: grid;
   grid-template: repeat(3, 720px) / 1fr 1200px 1fr;
   grid-template-areas:
@@ -51,14 +51,14 @@ footer {
   ;
 }
 
-.header-container {
+.header-inner {
   width: auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.footer-container {
+.footer-inner {
   display: flex;
   justify-content: space-between;
   padding: 32px 200px;
@@ -137,11 +137,11 @@ footer {
   max-width: 1200px;
   margin: 0 auto;
 }
-#topBanner-img {
+#topBanner-panda {
   background-image: url("../images/Img_home_top.png");
 }
 
-#bottomBanner-img {
+#bottomBanner-panda {
   background-image: url("../images/Img_home_bottom.png");
 }
 
@@ -267,12 +267,12 @@ footer {
     justify-content: end;
   }
 
-  .main-container {
+  .main-inner {
     display: block;
     
   }
 
-  .main-container img {
+  .main-inner img {
     width: 100%;
     height: 100%;
     padding: 24px;
@@ -349,7 +349,7 @@ footer {
     width: 100%;
   }
 
-  .footer-container {
+  .footer-inner{
     padding: 32px;
     row-gap: 60px;
     gap: 30px;

--- a/pandamarket/styles/signInUp.css
+++ b/pandamarket/styles/signInUp.css
@@ -113,16 +113,33 @@ input:focus {
   gap: 30px;
 }
 
+.OAuth > div {
+  white-space:nowrap;
+}
+
+/*mobile */
 @media (min-width: 375px) and (max-width: 767px) {
   .login-container {
     padding: 0 16px;
     margin: 24px auto;
+    width: auto;
+  }
+
+  .Oauth_img {
+    gap: 16px;
+  }
+
+  .logo a img {
+    width: 198px;
+    height: 66px;
   }
 }
 
+/* tablet */
 @media (min-width: 768px) and (max-width: 1199px) {
   .login-container {
     padding: 0 53px;
     margin: 48px auto;
   }
+
 }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면  ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] Input 에 유효한 값을 입력하면  ‘회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘회원가입’ 버튼을 누르면  “/signin” 로 이동합니다
- [x] 활성화된 ‘로그인’ 버튼을 누르면  “/items” 로 이동합니다
### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다


## 주요 변경사항

- 요구사항 이외 특별히 변경된 부분은 없고 html 부분에 id 정도 추가되었습니다.

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/6-Sprint-Mission/assets/105118884/db2b1c7d-c003-43c1-ae03-484d8400f6ba)

![image](https://github.com/codeit-bootcamp-frontend/6-Sprint-Mission/assets/105118884/6794299b-5676-4708-9139-2d53188b2cb9)

![image](https://github.com/codeit-bootcamp-frontend/6-Sprint-Mission/assets/105118884/deaa5922-b022-4e8b-aa6e-c00407a30485)

## 멘토에게

- 모듈로 분리하여 코드를 작성해봤습니다. 다 만들고 읽어보니 별거 없는데 막상 만들 때는 생각을 많이 했습니다.
- 변수이름이 너무 어렵습니다 다표현 하자니 너무 길어 별로고 짧으면 이해가 안될까 해서 최대한 고민 했지만 이게 제가 한코드에서 불편한 점 있으면 가감없이 알려주세요
- 제가 만든 방식보다 더 쉽거나 효율적인 방식이 있다면 알려주세요 이런 부분을 해본 경험이 별로 없기 때문에 아는 메서드만 사용해서 만들었는데 더 좋은 메서드가 있거나 더 간결하게 만들 수 있으면 좋겠습니다.(기능이 별게 없는데 코드가 많아진 것 같아서)
- 추가: 많은 고민 끝에 6시간에 걸쳐 이벤트 위임방식으로 전환 하였습니다 개인적으로 만족하는 부분이 있지만 저 혼자 계속 봐서 이젠 뭐가 좋은지 모르겠습니다 처음에 추상화를 고려하여 작성하였지만 가독성이 너무 떨어지는 느낌을 받아 전면 수정했습니다 다시 이렇게 만들라 하면  못할수도 있겠네요 피드백 기다리겠습니다 