### PR TITLE
[박진경] sprint4

### DIFF
--- a/Sprint-Mission2/index.html
+++ b/Sprint-Mission2/index.html
@@ -12,7 +12,7 @@
 <body>
   <header>
     <a href="./index.html"><img src="images/logo-image.png" alt="판다마켓 홈" width="153" height="51"></a>
-    <a href="signin.html" id="signinLinkButton" class="button">로그인</a>
+    <a href="signin.html" class="signinLinkButton button">로그인</a>
   </header>
   
   <main>
@@ -20,7 +20,7 @@
       <div id="hero-wrapper" class="wrapper">
         <h1>일상의 모든 물건을<br>
           거래해 보세요</h1>
-        <a href="/items" id="hero-button" class="button">구경하러 가기</a>
+        <a href="/items" class="hero-button button">구경하러 가기</a>
       </div>
     </section>
 

--- a/Sprint-Mission2/styles/auth.css
+++ b/Sprint-Mission2/styles/auth.css
@@ -61,8 +61,8 @@ input {
   width: 100%;
 }
 
-.input:focus {
-  border:1px solid #3692FF;
+input:focus {
+  border: 1px solid #3692FF;
 }
 
 .social-login-container {

--- a/Sprint-Mission2/styles/style.css
+++ b/Sprint-Mission2/styles/style.css
@@ -16,11 +16,11 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 200px;
+  padding: 0 16px;
   background-color: #FFFFFF;
 }
 
-#signinLinkButton {
+.signinLinkButton {
   background-color: #3692FF;
   color: #FFFFFF;
   font-size: 16px;
@@ -55,7 +55,7 @@ h1 {
   font-weight: 700;
 }
 
-#hero-button {
+.hero-button {
   padding: 16px 124px;
   font-size: 20px;
   font-weight: 600;
@@ -187,4 +187,38 @@ footer {
 
 .button:focus {
   background-color: #1251aa;
+}
+
+
+@media (min-width: 768px) {
+  header {
+    padding: 0 24px;
+  }
+
+  .wrapper {
+    padding: 0 24px;
+  }
+
+  #features {
+    padding-top: 24px;
+  }
+
+  .hero-button {
+    justify-content: center;
+  }
+  #hero h1 br {
+    display: none;
+  }
+  footer {
+    padding: 32px, 104px, 64px, 104px;
+  }
+}
+
+@media (min-width: 1200px) {
+  header {
+    padding: 0 200px;
+  } 
+  footer {
+    padding: 32px 200px 108px 200px;
+  }
 }


### PR DESCRIPTION
### 기본
공통

- [x] 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
PC: 1200px 이상
Tablet: 768px 이상 ~ 1199px 이하
Mobile: 375px 이상 ~ 767px 이하
375px 미만 사이즈의 디자인은 고려하지 않습니다

랜딩 페이지

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [ ] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

로그인, 회원가입 페이지 공통

- [ ] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

### 심화
- [ ] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ] 주소와 이미지는 자유롭게 설정하세요.


## 주요 변경사항
- 지난 한달 동안 스프린트 미션을 하다 최근에 갈아엎고 다시 시작했습니다.
- 아직 실력이 부족해서 주차에 맞게 따라가지 못하고 있고 이번주에는 sprint 미션 3까지를 목표로 작업했습니다. 
- 이전에 브랜치를 이미 sprint4까지 만들어두었어서 브랜치는 일단 part1-박진경-sprint4에 그대로 작업했습니다. 
- 브랜치와 PR 타이틀은 sprint4 이지만 작업 내용은 sprint3까지 내용입니다..!
- 
## 멘토에게

질문사항

- 판다마켓 로그인, 회원가입 페이지의 inpur에 focus 될 때 테두리가 파란색이 되도록 지정했는데 적용이 되지 않습니다. ( input:focus { } ) 왜 적용이 안되는지 잘 모르겠습니다ㅠㅠ
- 판다마켓 메인 화면과 로그인, 회원가입 페이지 모두 브라우저에서 화면크기를 80%로 해야 전체 크기가 맞는데, 브라우저 화면 크기 100%에서 딱 맞게 하려면 어떻게 해야하는지 잘 모르겠습니다!
- 반응형으로 판다마켓 메인 화면 banner의 판다 이미지가 태블릿, 모바일 사이즈일 때 가운데로 오게 하는 방법을 모르겠습니다.
- 판다마켓 메인 화면 banner의 '구경하러 가기' 버튼이 태블릿, 모바일 사이즈일 때 가운데로 오게 하는 방법이 궁금합니다. 
- 실력이 너무 부족해서 미션을 잘 따라가고 있지 못하고 있습니다 ㅠㅠ 최대한 빨리 따라잡아보겠습니다...
