### PR TITLE
[최소영] Sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="판다 마켓">
     <meta property="og:image" content="meta_logo.png">
-    <meta property="og:url" content="/">
+    <meta property="og:url" content="www.pandamarket.com">
     <meta property="og:type" content="website">
     <meta property="og:locale" content="ko_KR">
     <meta


### PR DESCRIPTION
## 요구사항
1. Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
2. 피그마 디자인에 맞게 페이지를 만들어 주세요.
3. React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

## 기본
### 공통
* 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
   - [x]  PC: 1200px 이상 
   - [x] Tablet: 768px 이상 ~ 1199px 이하
   - [x] Mobile: 375px 이상 ~ 767px 이하
   - [x] 375px 미만 사이즈의 디자인은 고려하지 않습니다

### 랜딩 페이지

- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.


### 로그인, 회원가입 페이지 공통

- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.

## 체크리스트 [심화, 미완]

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.

## 주요 변경사항
- 이번엔 로그인과 회원가입의 미디어쿼리를 작성하였습니다.
- 페이스북 메타 태그를 index.html 안에 작성하였습니다. (웹사이트 배포가 되지 않아서 링크는 "/"로 하였습니다.)

## 멘토에게
- 코드 주석에도 적어놨지만,
- "다른 부분은 일정 사이즈에서 요소가 움직이는걸 멈추는데, 
  판다마켓 로고와 타이틀 부분은 이상하게 브라우저가 줄어드는데로
  끝까지 줄어든다. 이유를 모르겠다.",
 " 'Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.' 
  이 조건을 위해 max-width로 width값을 변경했다가 레이아웃이 깨지는 참사가 발생했다.
  어떻게 해결 해야하는건지 모르겠다. "
  
  이 부분을 잘 모르겠습니다. 피드백 기다리겠습니다!